### PR TITLE
Make the octothorpe visible in docs

### DIFF
--- a/docs/innards/meaning_of_dollar.md
+++ b/docs/innards/meaning_of_dollar.md
@@ -51,7 +51,7 @@ Note that you can't use `$` with operators. For example:
 4 * (2 + 3)
 ```
 
-## Comparing $ and #
+## Comparing $ and # #
 
 So, `$` is used to join a parameter (on the right) with a function (on the left). `#` (and all its friends `|+|`, `|*|`, etc) are used to combine a pattern on the right with a pattern on the left. Check out the page `Pattern structure` in the `Basics` section.
 


### PR DESCRIPTION
This is a really  small change, I just noticed that the octothorp doesn't seem visible in the docs, and I think it's because of the special markdown meaning octothorps have for headers. I got this solution from https://stackoverflow.com/questions/32196555/