### PR TITLE
Replace literal octothorpe with HTML entity

### DIFF
--- a/docs/innards/meaning_of_dollar.md
+++ b/docs/innards/meaning_of_dollar.md
@@ -51,7 +51,7 @@ Note that you can't use `$` with operators. For example:
 4 * (2 + 3)
 ```
 
-## Comparing $ and # #
+## Comparing $ and &#35;
 
 So, `$` is used to join a parameter (on the right) with a function (on the left). `#` (and all its friends `|+|`, `|*|`, etc) are used to combine a pattern on the right with a pattern on the left. Check out the page `Pattern structure` in the `Basics` section.
 


### PR DESCRIPTION
OK, sorry to contribute two commits to fix a single character in some documentation. My last solution (#46) worked in the GitHub markdown preview tab, but didn't work when rendering to HTML. I'm not sure why and I'm not going to bother figuring that part out. Using an HTML entity instead of a literal `#` seems like a clearer approach anyways.