### PR TITLE
Update linux_install.md

### DIFF
--- a/docs/getting-started/linux_install.md
+++ b/docs/getting-started/linux_install.md
@@ -84,8 +84,10 @@ in the menus. Then type and run these two commands *(ignoring any
 complaints that cabal has of 'legacy v1 style of usage')*:
 ```bash
 cabal update
-cabal install tidal
+cabal install tidal --lib
 ```
+
+(If the last command doesn't work, try leaving off the `--lib`.)
 
 If you've never installed TidalCycles before, then the
 `cabal install tidal` step may take some time. At the end of the command

--- a/docs/getting-started/linux_install.md
+++ b/docs/getting-started/linux_install.md
@@ -87,7 +87,7 @@ cabal update
 cabal install tidal --lib
 ```
 
-(If the last command doesn't work, try leaving off the `--lib`.)
+(Depending on your cabal version, you might have to leave off the `--lib` on the last command.)
 
 If you've never installed TidalCycles before, then the
 `cabal install tidal` step may take some time. At the end of the command

--- a/docs/getting-started/linux_install.md
+++ b/docs/getting-started/linux_install.md
@@ -63,16 +63,18 @@ installation is done, you can exit the interpreter by pressing Ctrl + C.
 
 **III - SC3 Plugins**
 
-`SC3Plugins` is a community-made extension for SuperCollider. Installing it is **highly** recommended. You won't be able to use the default synthesizers provided with Tidal Cycles without it. Please be sure to read [these instructions](https://supercollider.github.io/sc3-plugins/) to get the extension.
-
-- **Ubuntu** / **Mint** / **Debian**: follow the instructions above.
-- **Arch** / **Manjaro**: there is an up-to-date package in the [Community repository](https://archlinux.org/packages/community/x86_64/sc3-plugins/).
-
 :::caution
 
 If you installed SuperCollider using the [build-supercollider](https://github.com/lvm/build-supercollider) method, you won't need to install them. SC3Plugins is compiled and installed by the script.
 
 :::
+  
+  
+`SC3Plugins` is a community-made extension for SuperCollider. Installing it is **highly** recommended. You won't be able to use the default synthesizers provided with Tidal Cycles without it. Please be sure to read [these instructions](https://supercollider.github.io/sc3-plugins/) to get the extension.
+
+- **Ubuntu** / **Mint** / **Debian**: follow the instructions above.
+- **Arch** / **Manjaro**: there is an up-to-date package in the [Community repository](https://archlinux.org/packages/community/x86_64/sc3-plugins/).
+
 
 ### Tidal Cycles
 
@@ -82,7 +84,7 @@ in the menus. Then type and run these two commands *(ignoring any
 complaints that cabal has of 'legacy v1 style of usage')*:
 ```bash
 cabal update
-cabal install tidal --lib
+cabal install tidal
 ```
 
 If you've never installed TidalCycles before, then the


### PR DESCRIPTION
I've just installed tidal-cycles on a clean Ubuntu 20.04 - suggest the following changes

- put the warning about SC3 plugins *before* the instructions, so people don't try and install it when they don't need to (like I did)
- removed `--lib` from the line `cabal install tidal`, because I couldn't get it to work with that option