### PR TITLE
Fix table format problem

### DIFF
--- a/docs/patternlib/tutorials/pattern_structure.md
+++ b/docs/patternlib/tutorials/pattern_structure.md
@@ -63,13 +63,13 @@ Note that `+` is actually an alias for `|+|`. So `|+` is to take the structure f
 
 | Function     | Both           | Left  | Right |
 |--------------|----------------|-------|-------|
-| Add          | `\|+\|` or (+) | `\|+` | `+\|` |
-| Substract    | `\|-\|` or (-) | `\|-` | `-\|` |
-| Multiply     | `\|*\|` or (*) | `\|*` | `*\|` |
-| Divide       | `\|/\|` or (/) | `\|/` | `/\|` |
-| Modulo       | `\|%\|` or (%) | `\|%` | `%\|` |
-| Left values  | `\|<\|` or (<) | `\|<` | `<\|` |
-| Right Values | `\|>\|` or (>) | `\|>` | `>\|` |
+| Add          | &vert;+&vert; or (+) | &vert;+ | +&vert; |
+| Subtract     | &vert;-&vert; or (-) | &vert;- | -&vert; |
+| Multiply     | &vert;&ast;&vert; or (*) | &vert;&ast; | &ast;&vert; |
+| Divide       | &vert;/&vert; or (/) | &vert;/ | /&vert; |
+| Modulo       | &vert;%&vert; or (%) | &vert;% | %&vert; |
+| Left values  | &vert;<&vert; or (<) | &vert;< | <&vert; |
+| Right Values | &vert;>&vert; or (>) | &vert;> | >&vert; |
 
 
 The last two are interesting, they let you only take values from one side. So for example you could take structure from the left, but values from the right with `|>`, for example:


### PR DESCRIPTION
Fix problem (hopefully) with table format when MD is converted to HTML on the Tidal Website.

Note: not sure how to test this in the full chain of events, but at least this version removes the \ escape characters that erroniously (and very confusingly) make it on to the [Tidal Web Site](http://tidalcycles.org/docs/patternlib/tutorials/pattern_structure).