### PR TITLE
Fix several small issues in documentation

### DIFF
--- a/docs/patternlib/tour/time.md
+++ b/docs/patternlib/tour/time.md
@@ -36,7 +36,7 @@ You can also use this function by its older alias, `density`.
 ```haskell
 Type: fastGap :: Pattern Time -> Pattern a -> Pattern a
 ```
-`fastGap` speeds up a pattern like `fast`, but rather than it playing multiple times as fast would it instead leaves a gap in the remaining space of the cycle. For example, the following will play the sound pattern `"bd sn"` only once but compressed into the first half of the cycle, i.e. twice as fast.
+`fastGap` (alias `densityGap`) speeds up a pattern like `fast`, but rather than it playing multiple times as fast would it instead leaves a gap in the remaining space of the cycle. For example, the following will play the sound pattern `"bd sn"` only once but compressed into the first half of the cycle, i.e. twice as fast.
 
 ```haskell
 d1 $ sound (fastGap 2 "bd sn")

--- a/docs/patternlib/tutorials/effects.md
+++ b/docs/patternlib/tutorials/effects.md
@@ -109,7 +109,7 @@ Be gentle with the resonance amount
 
 #### Bandpass filter
 
-* `bandf` / `bpf`: cutoff amount in hertz
+* `bandf` / `bpf`: center frequency in hertz
 * `bandq` / `bpq`: resonance
 
 #### Vowel

--- a/docs/patternlib/tutorials/effects.md
+++ b/docs/patternlib/tutorials/effects.md
@@ -110,7 +110,7 @@ Be gentle with the resonance amount
 #### Bandpass filter
 
 * `bandf` / `bpf`: cutoff amount in hertz
-* `bandq` / `bpfq`: resonance
+* `bandq` / `bpq`: resonance
 
 #### Vowel
 

--- a/docs/patternlib/tutorials/mini_notation.md
+++ b/docs/patternlib/tutorials/mini_notation.md
@@ -131,13 +131,13 @@ Elongate or `_` will extend the duration of an event for `x` steps:
 d2 $ s "bd _ _ hh*4"
 ```
 
-You might here a lot of silence between the first hit and the hi-hat. That's perfectly normal. Silence is cool too.
+You might hear a lot of silence between the first hit and the hi-hat. That's perfectly normal. Silence is cool too.
 
 ### Randomization
 
-You can use a question mark `?` to randomly remove some events from the patter, with a probability of `1/2`.
+You can use a question mark `?` to randomly remove some events from the pattern, with a probability of `1/2`. To use a different probabilty, use a number after the question mark.
 ```c
-d1 $ s "bd hh? bd hh?"
+d1 $ s "bd hh? bd hh?0.8"
 ```
 
 ### Random choice


### PR DESCRIPTION
While playing around a bit with TidalCycles I noticed some small errors and omissions in the documentation.
This Pull Request fixes the ones I found so far. Namely the following:
- Documented densityGap alias
- Fixed description in bandpass filter (the value is not the cutoff but the center frequency)
- Fixed resonance alias function of bandpass filter
- Added example for changing the probabilities with the ? in mini-notation