### PR TITLE
Added a needed line break to the command used

### DIFF
--- a/docs/getting-started/windows_install.md
+++ b/docs/getting-started/windows_install.md
@@ -29,7 +29,8 @@ windows to give a few security pop-ups for you to accept. Windows 7 users: pleas
 >  manager is required. If you haven't installed it previously, you can
 >   get it by running this command:
 >   ```shell
->    Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))```
+>    Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+>    ```
 
 **III - Installing Tidal Cycles**
 


### PR DESCRIPTION
moved the ``` markup to the next line, formatting it properly and allowing suitable copying of the command in the documentation