### PR TITLE
added more line breaks to commands

### DIFF
--- a/docs/getting-started/windows_install.md
+++ b/docs/getting-started/windows_install.md
@@ -34,7 +34,9 @@ windows to give a few security pop-ups for you to accept. Windows 7 users: pleas
 **III - Installing Tidal Cycles**
 
 Run the following command to install Tidal Cycles using Chocolatey:
->    ```shell choco install tidalcycles ```
+>    ```shell 
+>    choco install tidalcycles 
+>    ```
 
 *Note:* We are still working on the automatic installer. A lot of confusing information will scroll past. Please ignore messages about restarting Powershell. Just let the process run to the end.
 


### PR DESCRIPTION
choco install tidalcycles needs some line breaks so that the word "shell" is not seen as a syntax command
Since it is part of the markup, we add in some line breaks to format it correctly and to remove the word "shell"