### PR TITLE
clean up case-insensitive duplicates causing havoc on some fs

### DIFF
--- a/wiki-export-alternate/Accelerate.md
+++ b/wiki-export-alternate/Accelerate.md
@@ -1,7 +1,0 @@
----
-title: Accelerate
-permalink: wiki/Accelerate/
-redirect_to: /wiki/accelerate/
----
-
-You should automatically be redirected to [accelerate](/wiki/accelerate/)

--- a/wiki-export-alternate/Accelerate.mediawiki
+++ b/wiki-export-alternate/Accelerate.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[accelerate]]

--- a/wiki-export-alternate/AlmostAlways.md
+++ b/wiki-export-alternate/AlmostAlways.md
@@ -1,7 +1,0 @@
----
-title: AlmostAlways
-permalink: wiki/AlmostAlways/
-redirect_to: /wiki/sometimes#almostAlways/
----
-
-You should automatically be redirected to [sometimes#almostAlways](/wiki/sometimes#almostAlways/)

--- a/wiki-export-alternate/AlmostAlways.mediawiki
+++ b/wiki-export-alternate/AlmostAlways.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[sometimes#almostAlways]]

--- a/wiki-export-alternate/AlmostNever.md
+++ b/wiki-export-alternate/AlmostNever.md
@@ -1,7 +1,0 @@
----
-title: AlmostNever
-permalink: wiki/AlmostNever/
-redirect_to: /wiki/sometimes/
----
-
-You should automatically be redirected to [sometimes](/wiki/sometimes/)

--- a/wiki-export-alternate/AlmostNever.mediawiki
+++ b/wiki-export-alternate/AlmostNever.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[sometimes]]

--- a/wiki-export-alternate/Always.md
+++ b/wiki-export-alternate/Always.md
@@ -1,7 +1,0 @@
----
-title: Always
-permalink: wiki/Always/
-redirect_to: /wiki/sometimes/
----
-
-You should automatically be redirected to [sometimes](/wiki/sometimes/)

--- a/wiki-export-alternate/Always.mediawiki
+++ b/wiki-export-alternate/Always.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[sometimes]]

--- a/wiki-export-alternate/Arpeggiate.md
+++ b/wiki-export-alternate/Arpeggiate.md
@@ -1,7 +1,0 @@
----
-title: Arpeggiate
-permalink: wiki/Arpeggiate/
-redirect_to: /wiki/arpeggiate/
----
-
-You should automatically be redirected to [arpeggiate](/wiki/arpeggiate/)

--- a/wiki-export-alternate/Arpeggiate.mediawiki
+++ b/wiki-export-alternate/Arpeggiate.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[arpeggiate]]

--- a/wiki-export-alternate/Arpg.md
+++ b/wiki-export-alternate/Arpg.md
@@ -1,7 +1,0 @@
----
-title: Arpg
-permalink: wiki/Arpg/
-redirect_to: /wiki/arpeggiate/
----
-
-You should automatically be redirected to [arpeggiate](/wiki/arpeggiate/)

--- a/wiki-export-alternate/Arpg.mediawiki
+++ b/wiki-export-alternate/Arpg.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[arpeggiate]]

--- a/wiki-export-alternate/Attack.md
+++ b/wiki-export-alternate/Attack.md
@@ -1,7 +1,0 @@
----
-title: Attack
-permalink: wiki/Attack/
-redirect_to: /wiki/attack/
----
-
-You should automatically be redirected to [attack](/wiki/attack/)

--- a/wiki-export-alternate/Attack.mediawiki
+++ b/wiki-export-alternate/Attack.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[attack]]

--- a/wiki-export-alternate/Bandf.md
+++ b/wiki-export-alternate/Bandf.md
@@ -1,7 +1,0 @@
----
-title: Bandf
-permalink: wiki/Bandf/
-redirect_to: /wiki/bandf/
----
-
-You should automatically be redirected to [bandf](/wiki/bandf/)

--- a/wiki-export-alternate/Bandf.mediawiki
+++ b/wiki-export-alternate/Bandf.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[bandf]]

--- a/wiki-export-alternate/Bandq.md
+++ b/wiki-export-alternate/Bandq.md
@@ -1,7 +1,0 @@
----
-title: Bandq
-permalink: wiki/Bandq/
-redirect_to: /wiki/bandq/
----
-
-You should automatically be redirected to [bandq](/wiki/bandq/)

--- a/wiki-export-alternate/Bandq.mediawiki
+++ b/wiki-export-alternate/Bandq.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[bandq]]

--- a/wiki-export-alternate/Begin.md
+++ b/wiki-export-alternate/Begin.md
@@ -1,7 +1,0 @@
----
-title: Begin
-permalink: wiki/Begin/
-redirect_to: /wiki/begin/
----
-
-You should automatically be redirected to [begin](/wiki/begin/)

--- a/wiki-export-alternate/Begin.mediawiki
+++ b/wiki-export-alternate/Begin.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[begin]]

--- a/wiki-export-alternate/Bpf.md
+++ b/wiki-export-alternate/Bpf.md
@@ -1,7 +1,0 @@
----
-title: Bpf
-permalink: wiki/Bpf/
-redirect_to: /wiki/bpf/
----
-
-You should automatically be redirected to [bpf](/wiki/bpf/)

--- a/wiki-export-alternate/Bpf.mediawiki
+++ b/wiki-export-alternate/Bpf.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[bpf]]

--- a/wiki-export-alternate/Bpq.md
+++ b/wiki-export-alternate/Bpq.md
@@ -1,7 +1,0 @@
----
-title: Bpq
-permalink: wiki/Bpq/
-redirect_to: /wiki/bpq/
----
-
-You should automatically be redirected to [bpq](/wiki/bpq/)

--- a/wiki-export-alternate/Bpq.mediawiki
+++ b/wiki-export-alternate/Bpq.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[bpq]]

--- a/wiki-export-alternate/ChooseBy.md
+++ b/wiki-export-alternate/ChooseBy.md
@@ -1,7 +1,0 @@
----
-title: ChooseBy
-permalink: wiki/ChooseBy/
-redirect_to: /wiki/choose/
----
-
-You should automatically be redirected to [choose](/wiki/choose/)

--- a/wiki-export-alternate/ChooseBy.mediawiki
+++ b/wiki-export-alternate/ChooseBy.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[choose]]

--- a/wiki-export-alternate/Chop.md
+++ b/wiki-export-alternate/Chop.md
@@ -1,7 +1,0 @@
----
-title: Chop
-permalink: wiki/Chop/
-redirect_to: /wiki/chop/
----
-
-You should automatically be redirected to [chop](/wiki/chop/)

--- a/wiki-export-alternate/Chop.mediawiki
+++ b/wiki-export-alternate/Chop.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[chop]]

--- a/wiki-export-alternate/Chunk'.md
+++ b/wiki-export-alternate/Chunk'.md
@@ -1,7 +1,0 @@
----
-title: Chunk'
-permalink: wiki/Chunk'/
-redirect_to: /wiki/chunk#chunk'/
----
-
-You should automatically be redirected to [chunk#chunk'](/wiki/chunk#chunk'/)

--- a/wiki-export-alternate/Chunk'.mediawiki
+++ b/wiki-export-alternate/Chunk'.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[chunk#chunk']]

--- a/wiki-export-alternate/Chunk.md
+++ b/wiki-export-alternate/Chunk.md
@@ -1,7 +1,0 @@
----
-title: Chunk
-permalink: wiki/Chunk/
-redirect_to: /wiki/chunk/
----
-
-You should automatically be redirected to [chunk](/wiki/chunk/)

--- a/wiki-export-alternate/Chunk.mediawiki
+++ b/wiki-export-alternate/Chunk.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[chunk]]

--- a/wiki-export-alternate/Coarse.md
+++ b/wiki-export-alternate/Coarse.md
@@ -1,7 +1,0 @@
----
-title: Coarse
-permalink: wiki/Coarse/
-redirect_to: /wiki/coarse/
----
-
-You should automatically be redirected to [coarse](/wiki/coarse/)

--- a/wiki-export-alternate/Coarse.mediawiki
+++ b/wiki-export-alternate/Coarse.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[coarse]]

--- a/wiki-export-alternate/Cosine.md
+++ b/wiki-export-alternate/Cosine.md
@@ -1,7 +1,0 @@
----
-title: Cosine
-permalink: wiki/Cosine/
-redirect_to: /wiki/Oscillators#cosine/
----
-
-You should automatically be redirected to [Oscillators#cosine](/wiki/Oscillators#cosine/)

--- a/wiki-export-alternate/Cosine.mediawiki
+++ b/wiki-export-alternate/Cosine.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[Oscillators#cosine]]

--- a/wiki-export-alternate/Crush.md
+++ b/wiki-export-alternate/Crush.md
@@ -1,7 +1,0 @@
----
-title: Crush
-permalink: wiki/Crush/
-redirect_to: /wiki/crush/
----
-
-You should automatically be redirected to [crush](/wiki/crush/)

--- a/wiki-export-alternate/Crush.mediawiki
+++ b/wiki-export-alternate/Crush.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[crush]]

--- a/wiki-export-alternate/Cut.md
+++ b/wiki-export-alternate/Cut.md
@@ -1,7 +1,0 @@
----
-title: Cut
-permalink: wiki/Cut/
-redirect_to: /wiki/cut/
----
-
-You should automatically be redirected to [cut](/wiki/cut/)

--- a/wiki-export-alternate/Cut.mediawiki
+++ b/wiki-export-alternate/Cut.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[cut]]

--- a/wiki-export-alternate/Cutoff.md
+++ b/wiki-export-alternate/Cutoff.md
@@ -1,7 +1,0 @@
----
-title: Cutoff
-permalink: wiki/Cutoff/
-redirect_to: /wiki/cutoff/
----
-
-You should automatically be redirected to [cutoff](/wiki/cutoff/)

--- a/wiki-export-alternate/Cutoff.mediawiki
+++ b/wiki-export-alternate/Cutoff.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[cutoff]]

--- a/wiki-export-alternate/Degrade.md
+++ b/wiki-export-alternate/Degrade.md
@@ -1,7 +1,0 @@
----
-title: Degrade
-permalink: wiki/Degrade/
-redirect_to: /wiki/degrade/
----
-
-You should automatically be redirected to [degrade](/wiki/degrade/)

--- a/wiki-export-alternate/Degrade.mediawiki
+++ b/wiki-export-alternate/Degrade.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[degrade]]

--- a/wiki-export-alternate/DegradeBy.md
+++ b/wiki-export-alternate/DegradeBy.md
@@ -1,7 +1,0 @@
----
-title: DegradeBy
-permalink: wiki/DegradeBy/
-redirect_to: /wiki/degrade#degradeBy/
----
-
-You should automatically be redirected to [degrade#degradeBy](/wiki/degrade#degradeBy/)

--- a/wiki-export-alternate/DegradeBy.mediawiki
+++ b/wiki-export-alternate/DegradeBy.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[degrade#degradeBy]]

--- a/wiki-export-alternate/Delay.md
+++ b/wiki-export-alternate/Delay.md
@@ -1,7 +1,0 @@
----
-title: Delay
-permalink: wiki/Delay/
-redirect_to: /wiki/delay/
----
-
-You should automatically be redirected to [delay](/wiki/delay/)

--- a/wiki-export-alternate/Delay.mediawiki
+++ b/wiki-export-alternate/Delay.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[delay]]

--- a/wiki-export-alternate/Delayfb.md
+++ b/wiki-export-alternate/Delayfb.md
@@ -1,7 +1,0 @@
----
-title: Delayfb
-permalink: wiki/Delayfb/
-redirect_to: /wiki/delayfeedback/
----
-
-You should automatically be redirected to [delayfeedback](/wiki/delayfeedback/)

--- a/wiki-export-alternate/Delayfb.mediawiki
+++ b/wiki-export-alternate/Delayfb.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[delayfeedback]]

--- a/wiki-export-alternate/Delayfeedback.md
+++ b/wiki-export-alternate/Delayfeedback.md
@@ -1,7 +1,0 @@
----
-title: Delayfeedback
-permalink: wiki/Delayfeedback/
-redirect_to: /wiki/delayfeedback/
----
-
-You should automatically be redirected to [delayfeedback](/wiki/delayfeedback/)

--- a/wiki-export-alternate/Delayfeedback.mediawiki
+++ b/wiki-export-alternate/Delayfeedback.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[delayfeedback]]

--- a/wiki-export-alternate/Delaytime.md
+++ b/wiki-export-alternate/Delaytime.md
@@ -1,7 +1,0 @@
----
-title: Delaytime
-permalink: wiki/Delaytime/
-redirect_to: /wiki/delaytime/
----
-
-You should automatically be redirected to [delaytime](/wiki/delaytime/)

--- a/wiki-export-alternate/Delaytime.mediawiki
+++ b/wiki-export-alternate/Delaytime.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[delaytime]]

--- a/wiki-export-alternate/Density.md
+++ b/wiki-export-alternate/Density.md
@@ -1,7 +1,0 @@
----
-title: Density
-permalink: wiki/Density/
-redirect_to: /wiki/fast/
----
-
-You should automatically be redirected to [fast](/wiki/fast/)

--- a/wiki-export-alternate/Density.mediawiki
+++ b/wiki-export-alternate/Density.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[fast]]

--- a/wiki-export-alternate/Discretise.md
+++ b/wiki-export-alternate/Discretise.md
@@ -1,7 +1,0 @@
----
-title: Discretise
-permalink: wiki/Discretise/
-redirect_to: /wiki/segment/
----
-
-You should automatically be redirected to [segment](/wiki/segment/)

--- a/wiki-export-alternate/Discretise.mediawiki
+++ b/wiki-export-alternate/Discretise.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[segment]]

--- a/wiki-export-alternate/End.md
+++ b/wiki-export-alternate/End.md
@@ -1,7 +1,0 @@
----
-title: End
-permalink: wiki/End/
-redirect_to: /wiki/end/
----
-
-You should automatically be redirected to [end](/wiki/end/)

--- a/wiki-export-alternate/End.mediawiki
+++ b/wiki-export-alternate/End.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[end]]

--- a/wiki-export-alternate/Every.md
+++ b/wiki-export-alternate/Every.md
@@ -1,7 +1,0 @@
----
-title: Every
-permalink: wiki/Every/
-redirect_to: /wiki/every/
----
-
-You should automatically be redirected to [every](/wiki/every/)

--- a/wiki-export-alternate/Every.mediawiki
+++ b/wiki-export-alternate/Every.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[every]]

--- a/wiki-export-alternate/Fast.md
+++ b/wiki-export-alternate/Fast.md
@@ -1,7 +1,0 @@
----
-title: Fast
-permalink: wiki/Fast/
-redirect_to: /wiki/fast/
----
-
-You should automatically be redirected to [fast](/wiki/fast/)

--- a/wiki-export-alternate/Fast.mediawiki
+++ b/wiki-export-alternate/Fast.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[fast]]

--- a/wiki-export-alternate/FastAppend.md
+++ b/wiki-export-alternate/FastAppend.md
@@ -1,7 +1,0 @@
----
-title: FastAppend
-permalink: wiki/FastAppend/
-redirect_to: /wiki/fastAppend/
----
-
-You should automatically be redirected to [fastAppend](/wiki/fastAppend/)

--- a/wiki-export-alternate/FastAppend.mediawiki
+++ b/wiki-export-alternate/FastAppend.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[fastAppend]]

--- a/wiki-export-alternate/Fit'.md
+++ b/wiki-export-alternate/Fit'.md
@@ -1,7 +1,0 @@
----
-title: Fit'
-permalink: wiki/Fit'/
-redirect_to: /wiki/fit'/
----
-
-You should automatically be redirected to [fit'](/wiki/fit'/)

--- a/wiki-export-alternate/Fit'.mediawiki
+++ b/wiki-export-alternate/Fit'.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[fit']]

--- a/wiki-export-alternate/Fit.md
+++ b/wiki-export-alternate/Fit.md
@@ -1,7 +1,0 @@
----
-title: Fit
-permalink: wiki/Fit/
-redirect_to: /wiki/fit/
----
-
-You should automatically be redirected to [fit](/wiki/fit/)

--- a/wiki-export-alternate/Fit.mediawiki
+++ b/wiki-export-alternate/Fit.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[fit]]

--- a/wiki-export-alternate/Fix.md
+++ b/wiki-export-alternate/Fix.md
@@ -1,7 +1,0 @@
----
-title: Fix
-permalink: wiki/Fix/
-redirect_to: /wiki/fix/
----
-
-You should automatically be redirected to [fix](/wiki/fix/)

--- a/wiki-export-alternate/Fix.mediawiki
+++ b/wiki-export-alternate/Fix.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[fix]]

--- a/wiki-export-alternate/FoldEvery.md
+++ b/wiki-export-alternate/FoldEvery.md
@@ -1,7 +1,0 @@
----
-title: FoldEvery
-permalink: wiki/FoldEvery/
-redirect_to: /wiki/foldEvery/
----
-
-You should automatically be redirected to [foldEvery](/wiki/foldEvery/)

--- a/wiki-export-alternate/FoldEvery.mediawiki
+++ b/wiki-export-alternate/FoldEvery.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[foldEvery]]

--- a/wiki-export-alternate/Gain.md
+++ b/wiki-export-alternate/Gain.md
@@ -1,7 +1,0 @@
----
-title: Gain
-permalink: wiki/Gain/
-redirect_to: /wiki/gain/
----
-
-You should automatically be redirected to [gain](/wiki/gain/)

--- a/wiki-export-alternate/Gain.mediawiki
+++ b/wiki-export-alternate/Gain.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[gain]]

--- a/wiki-export-alternate/Gap.md
+++ b/wiki-export-alternate/Gap.md
@@ -1,7 +1,0 @@
----
-title: Gap
-permalink: wiki/Gap/
-redirect_to: /wiki/gap/
----
-
-You should automatically be redirected to [gap](/wiki/gap/)

--- a/wiki-export-alternate/Gap.mediawiki
+++ b/wiki-export-alternate/Gap.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[gap]]

--- a/wiki-export-alternate/Hcutoff.md
+++ b/wiki-export-alternate/Hcutoff.md
@@ -1,7 +1,0 @@
----
-title: Hcutoff
-permalink: wiki/Hcutoff/
-redirect_to: /wiki/hcutoff/
----
-
-You should automatically be redirected to [hcutoff](/wiki/hcutoff/)

--- a/wiki-export-alternate/Hcutoff.mediawiki
+++ b/wiki-export-alternate/Hcutoff.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[hcutoff]]

--- a/wiki-export-alternate/Hpf.md
+++ b/wiki-export-alternate/Hpf.md
@@ -1,7 +1,0 @@
----
-title: Hpf
-permalink: wiki/Hpf/
-redirect_to: /wiki/hpf/
----
-
-You should automatically be redirected to [hpf](/wiki/hpf/)

--- a/wiki-export-alternate/Hpf.mediawiki
+++ b/wiki-export-alternate/Hpf.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[hpf]]

--- a/wiki-export-alternate/Hpq.md
+++ b/wiki-export-alternate/Hpq.md
@@ -1,7 +1,0 @@
----
-title: Hpq
-permalink: wiki/Hpq/
-redirect_to: /wiki/hpq/
----
-
-You should automatically be redirected to [hpq](/wiki/hpq/)

--- a/wiki-export-alternate/Hpq.mediawiki
+++ b/wiki-export-alternate/Hpq.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[hpq]]

--- a/wiki-export-alternate/Hresonance.md
+++ b/wiki-export-alternate/Hresonance.md
@@ -1,7 +1,0 @@
----
-title: Hresonance
-permalink: wiki/Hresonance/
-redirect_to: /wiki/hresonance/
----
-
-You should automatically be redirected to [hresonance](/wiki/hresonance/)

--- a/wiki-export-alternate/Hresonance.mediawiki
+++ b/wiki-export-alternate/Hresonance.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[hresonance]]

--- a/wiki-export-alternate/Hurry.md
+++ b/wiki-export-alternate/Hurry.md
@@ -1,7 +1,0 @@
----
-title: Hurry
-permalink: wiki/Hurry/
-redirect_to: /wiki/hurry/
----
-
-You should automatically be redirected to [hurry](/wiki/hurry/)

--- a/wiki-export-alternate/Hurry.mediawiki
+++ b/wiki-export-alternate/Hurry.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[hurry]]

--- a/wiki-export-alternate/Ifp.md
+++ b/wiki-export-alternate/Ifp.md
@@ -1,7 +1,0 @@
----
-title: Ifp
-permalink: wiki/Ifp/
-redirect_to: /wiki/ifp/
----
-
-You should automatically be redirected to [ifp](/wiki/ifp/)

--- a/wiki-export-alternate/Ifp.mediawiki
+++ b/wiki-export-alternate/Ifp.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[ifp]]

--- a/wiki-export-alternate/Interlace.md
+++ b/wiki-export-alternate/Interlace.md
@@ -1,7 +1,0 @@
----
-title: Interlace
-permalink: wiki/Interlace/
-redirect_to: /wiki/interlace/
----
-
-You should automatically be redirected to [interlace](/wiki/interlace/)

--- a/wiki-export-alternate/Interlace.mediawiki
+++ b/wiki-export-alternate/Interlace.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[interlace]]

--- a/wiki-export-alternate/Irand.md
+++ b/wiki-export-alternate/Irand.md
@@ -1,7 +1,0 @@
----
-title: Irand
-permalink: wiki/Irand/
-redirect_to: /wiki/irand/
----
-
-You should automatically be redirected to [irand](/wiki/irand/)

--- a/wiki-export-alternate/Irand.mediawiki
+++ b/wiki-export-alternate/Irand.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[irand]]

--- a/wiki-export-alternate/Isaw.md
+++ b/wiki-export-alternate/Isaw.md
@@ -1,7 +1,0 @@
----
-title: Isaw
-permalink: wiki/Isaw/
-redirect_to: /wiki/isaw/
----
-
-You should automatically be redirected to [isaw](/wiki/isaw/)

--- a/wiki-export-alternate/Isaw.mediawiki
+++ b/wiki-export-alternate/Isaw.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[isaw]]

--- a/wiki-export-alternate/Iter'.md
+++ b/wiki-export-alternate/Iter'.md
@@ -1,7 +1,0 @@
----
-title: Iter'
-permalink: wiki/Iter'/
-redirect_to: /wiki/iter'/
----
-
-You should automatically be redirected to [iter'](/wiki/iter'/)

--- a/wiki-export-alternate/Iter'.mediawiki
+++ b/wiki-export-alternate/Iter'.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[iter']]

--- a/wiki-export-alternate/Iter.md
+++ b/wiki-export-alternate/Iter.md
@@ -1,7 +1,0 @@
----
-title: Iter
-permalink: wiki/Iter/
-redirect_to: /wiki/iter/
----
-
-You should automatically be redirected to [iter](/wiki/iter/)

--- a/wiki-export-alternate/Iter.mediawiki
+++ b/wiki-export-alternate/Iter.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[iter]]

--- a/wiki-export-alternate/Jux.md
+++ b/wiki-export-alternate/Jux.md
@@ -1,7 +1,0 @@
----
-title: Jux
-permalink: wiki/Jux/
-redirect_to: /wiki/jux/
----
-
-You should automatically be redirected to [jux](/wiki/jux/)

--- a/wiki-export-alternate/Jux.mediawiki
+++ b/wiki-export-alternate/Jux.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[jux]]

--- a/wiki-export-alternate/JuxBy.md
+++ b/wiki-export-alternate/JuxBy.md
@@ -1,7 +1,0 @@
----
-title: JuxBy
-permalink: wiki/JuxBy/
-redirect_to: /wiki/juxBy/
----
-
-You should automatically be redirected to [juxBy](/wiki/juxBy/)

--- a/wiki-export-alternate/JuxBy.mediawiki
+++ b/wiki-export-alternate/JuxBy.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[juxBy]]

--- a/wiki-export-alternate/Linger.md
+++ b/wiki-export-alternate/Linger.md
@@ -1,7 +1,0 @@
----
-title: Linger
-permalink: wiki/Linger/
-redirect_to: /wiki/linger/
----
-
-You should automatically be redirected to [linger](/wiki/linger/)

--- a/wiki-export-alternate/Linger.mediawiki
+++ b/wiki-export-alternate/Linger.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[linger]]

--- a/wiki-export-alternate/LoopAt.md
+++ b/wiki-export-alternate/LoopAt.md
@@ -1,7 +1,0 @@
----
-title: LoopAt
-permalink: wiki/LoopAt/
-redirect_to: /wiki/loopAt/
----
-
-You should automatically be redirected to [loopAt](/wiki/loopAt/)

--- a/wiki-export-alternate/LoopAt.mediawiki
+++ b/wiki-export-alternate/LoopAt.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[loopAt]]

--- a/wiki-export-alternate/Lpf.md
+++ b/wiki-export-alternate/Lpf.md
@@ -1,7 +1,0 @@
----
-title: Lpf
-permalink: wiki/Lpf/
-redirect_to: /wiki/lpf/
----
-
-You should automatically be redirected to [lpf](/wiki/lpf/)

--- a/wiki-export-alternate/Lpf.mediawiki
+++ b/wiki-export-alternate/Lpf.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[lpf]]

--- a/wiki-export-alternate/Lpq.md
+++ b/wiki-export-alternate/Lpq.md
@@ -1,7 +1,0 @@
----
-title: Lpq
-permalink: wiki/Lpq/
-redirect_to: /wiki/lpq/
----
-
-You should automatically be redirected to [lpq](/wiki/lpq/)

--- a/wiki-export-alternate/Lpq.mediawiki
+++ b/wiki-export-alternate/Lpq.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[lpq]]

--- a/wiki-export-alternate/Mask.md
+++ b/wiki-export-alternate/Mask.md
@@ -1,7 +1,0 @@
----
-title: Mask
-permalink: wiki/Mask/
-redirect_to: /wiki/mask/
----
-
-You should automatically be redirected to [mask](/wiki/mask/)

--- a/wiki-export-alternate/Mask.mediawiki
+++ b/wiki-export-alternate/Mask.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[mask]]

--- a/wiki-export-alternate/Midichan.md
+++ b/wiki-export-alternate/Midichan.md
@@ -1,7 +1,0 @@
----
-title: Midichan
-permalink: wiki/Midichan/
-redirect_to: /wiki/midichan/
----
-
-You should automatically be redirected to [midichan](/wiki/midichan/)

--- a/wiki-export-alternate/Midichan.mediawiki
+++ b/wiki-export-alternate/Midichan.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[midichan]]

--- a/wiki-export-alternate/Midicmd.md
+++ b/wiki-export-alternate/Midicmd.md
@@ -1,7 +1,0 @@
----
-title: Midicmd
-permalink: wiki/Midicmd/
-redirect_to: /wiki/midicmd/
----
-
-You should automatically be redirected to [midicmd](/wiki/midicmd/)

--- a/wiki-export-alternate/Midicmd.mediawiki
+++ b/wiki-export-alternate/Midicmd.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[midicmd]]

--- a/wiki-export-alternate/Midinote.md
+++ b/wiki-export-alternate/Midinote.md
@@ -1,7 +1,0 @@
----
-title: Midinote
-permalink: wiki/Midinote/
-redirect_to: /wiki/midinote/
----
-
-You should automatically be redirected to [midinote](/wiki/midinote/)

--- a/wiki-export-alternate/Midinote.mediawiki
+++ b/wiki-export-alternate/Midinote.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[midinote]]

--- a/wiki-export-alternate/Mono.md
+++ b/wiki-export-alternate/Mono.md
@@ -1,7 +1,0 @@
----
-title: Mono
-permalink: wiki/Mono/
-redirect_to: /wiki/mono/
----
-
-You should automatically be redirected to [mono](/wiki/mono/)

--- a/wiki-export-alternate/Mono.mediawiki
+++ b/wiki-export-alternate/Mono.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[mono]]

--- a/wiki-export-alternate/N.md
+++ b/wiki-export-alternate/N.md
@@ -1,7 +1,0 @@
----
-title: N
-permalink: wiki/N/
-redirect_to: /wiki/n/
----
-
-You should automatically be redirected to [n](/wiki/n/)

--- a/wiki-export-alternate/N.mediawiki
+++ b/wiki-export-alternate/N.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[n]]

--- a/wiki-export-alternate/Nudge.md
+++ b/wiki-export-alternate/Nudge.md
@@ -1,7 +1,0 @@
----
-title: Nudge
-permalink: wiki/Nudge/
-redirect_to: /wiki/nudge/
----
-
-You should automatically be redirected to [nudge](/wiki/nudge/)

--- a/wiki-export-alternate/Nudge.mediawiki
+++ b/wiki-export-alternate/Nudge.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[nudge]]

--- a/wiki-export-alternate/Often.md
+++ b/wiki-export-alternate/Often.md
@@ -1,7 +1,0 @@
----
-title: Often
-permalink: wiki/Often/
-redirect_to: /wiki/often/
----
-
-You should automatically be redirected to [often](/wiki/often/)

--- a/wiki-export-alternate/Often.mediawiki
+++ b/wiki-export-alternate/Often.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[often]]

--- a/wiki-export-alternate/Overlay.md
+++ b/wiki-export-alternate/Overlay.md
@@ -1,7 +1,0 @@
----
-title: Overlay
-permalink: wiki/Overlay/
-redirect_to: /wiki/overlay/
----
-
-You should automatically be redirected to [overlay](/wiki/overlay/)

--- a/wiki-export-alternate/Overlay.mediawiki
+++ b/wiki-export-alternate/Overlay.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[overlay]]

--- a/wiki-export-alternate/Overlay_(operator).md
+++ b/wiki-export-alternate/Overlay_(operator).md
@@ -1,7 +1,0 @@
----
-title: Overlay (operator)
-permalink: wiki/Overlay_(operator)/
-redirect_to: /wiki/overlay_(operator)/
----
-
-You should automatically be redirected to [overlay (operator)](/wiki/overlay_(operator)/)

--- a/wiki-export-alternate/Overlay_(operator).mediawiki
+++ b/wiki-export-alternate/Overlay_(operator).mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[overlay (operator)]]

--- a/wiki-export-alternate/Palindrome.md
+++ b/wiki-export-alternate/Palindrome.md
@@ -1,7 +1,0 @@
----
-title: Palindrome
-permalink: wiki/Palindrome/
-redirect_to: /wiki/palindrome/
----
-
-You should automatically be redirected to [palindrome](/wiki/palindrome/)

--- a/wiki-export-alternate/Palindrome.mediawiki
+++ b/wiki-export-alternate/Palindrome.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[palindrome]]

--- a/wiki-export-alternate/Pan.md
+++ b/wiki-export-alternate/Pan.md
@@ -1,7 +1,0 @@
----
-title: Pan
-permalink: wiki/Pan/
-redirect_to: /wiki/pan/
----
-
-You should automatically be redirected to [pan](/wiki/pan/)

--- a/wiki-export-alternate/Pan.mediawiki
+++ b/wiki-export-alternate/Pan.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[pan]]

--- a/wiki-export-alternate/Ply.md
+++ b/wiki-export-alternate/Ply.md
@@ -1,7 +1,0 @@
----
-title: Ply
-permalink: wiki/Ply/
-redirect_to: /wiki/ply/
----
-
-You should automatically be redirected to [ply](/wiki/ply/)

--- a/wiki-export-alternate/Ply.mediawiki
+++ b/wiki-export-alternate/Ply.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[ply]]

--- a/wiki-export-alternate/Rand.md
+++ b/wiki-export-alternate/Rand.md
@@ -1,7 +1,0 @@
----
-title: Rand
-permalink: wiki/Rand/
-redirect_to: /wiki/rand/
----
-
-You should automatically be redirected to [rand](/wiki/rand/)

--- a/wiki-export-alternate/Rand.mediawiki
+++ b/wiki-export-alternate/Rand.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[rand]]

--- a/wiki-export-alternate/Randcat.md
+++ b/wiki-export-alternate/Randcat.md
@@ -1,7 +1,0 @@
----
-title: Randcat
-permalink: wiki/Randcat/
-redirect_to: /wiki/randcat/
----
-
-You should automatically be redirected to [randcat](/wiki/randcat/)

--- a/wiki-export-alternate/Randcat.mediawiki
+++ b/wiki-export-alternate/Randcat.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[randcat]]

--- a/wiki-export-alternate/Range.md
+++ b/wiki-export-alternate/Range.md
@@ -1,7 +1,0 @@
----
-title: Range
-permalink: wiki/Range/
-redirect_to: /wiki/range/
----
-
-You should automatically be redirected to [range](/wiki/range/)

--- a/wiki-export-alternate/Range.mediawiki
+++ b/wiki-export-alternate/Range.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[range]]

--- a/wiki-export-alternate/Rangex.md
+++ b/wiki-export-alternate/Rangex.md
@@ -1,7 +1,0 @@
----
-title: Rangex
-permalink: wiki/Rangex/
-redirect_to: /wiki/rangex/
----
-
-You should automatically be redirected to [rangex](/wiki/rangex/)

--- a/wiki-export-alternate/Rangex.mediawiki
+++ b/wiki-export-alternate/Rangex.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[rangex]]

--- a/wiki-export-alternate/Rarely.md
+++ b/wiki-export-alternate/Rarely.md
@@ -1,7 +1,0 @@
----
-title: Rarely
-permalink: wiki/Rarely/
-redirect_to: /wiki/rarely/
----
-
-You should automatically be redirected to [rarely](/wiki/rarely/)

--- a/wiki-export-alternate/Rarely.mediawiki
+++ b/wiki-export-alternate/Rarely.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[rarely]]

--- a/wiki-export-alternate/Release.md
+++ b/wiki-export-alternate/Release.md
@@ -1,7 +1,0 @@
----
-title: Release
-permalink: wiki/Release/
-redirect_to: /wiki/release/
----
-
-You should automatically be redirected to [release](/wiki/release/)

--- a/wiki-export-alternate/Release.mediawiki
+++ b/wiki-export-alternate/Release.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[release]]

--- a/wiki-export-alternate/RepeatCycles.md
+++ b/wiki-export-alternate/RepeatCycles.md
@@ -1,7 +1,0 @@
----
-title: RepeatCycles
-permalink: wiki/RepeatCycles/
-redirect_to: /wiki/repeatCycles/
----
-
-You should automatically be redirected to [repeatCycles](/wiki/repeatCycles/)

--- a/wiki-export-alternate/RepeatCycles.mediawiki
+++ b/wiki-export-alternate/RepeatCycles.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[repeatCycles]]

--- a/wiki-export-alternate/Resonance.md
+++ b/wiki-export-alternate/Resonance.md
@@ -1,7 +1,0 @@
----
-title: Resonance
-permalink: wiki/Resonance/
-redirect_to: /wiki/resonance/
----
-
-You should automatically be redirected to [resonance](/wiki/resonance/)

--- a/wiki-export-alternate/Resonance.mediawiki
+++ b/wiki-export-alternate/Resonance.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[resonance]]

--- a/wiki-export-alternate/Rev.md
+++ b/wiki-export-alternate/Rev.md
@@ -1,7 +1,0 @@
----
-title: Rev
-permalink: wiki/Rev/
-redirect_to: /wiki/rev/
----
-
-You should automatically be redirected to [rev](/wiki/rev/)

--- a/wiki-export-alternate/Rev.mediawiki
+++ b/wiki-export-alternate/Rev.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[rev]]

--- a/wiki-export-alternate/Room.md
+++ b/wiki-export-alternate/Room.md
@@ -1,7 +1,0 @@
----
-title: Room
-permalink: wiki/Room/
-redirect_to: /wiki/room/
----
-
-You should automatically be redirected to [room](/wiki/room/)

--- a/wiki-export-alternate/Room.mediawiki
+++ b/wiki-export-alternate/Room.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[room]]

--- a/wiki-export-alternate/Rot.md
+++ b/wiki-export-alternate/Rot.md
@@ -1,7 +1,0 @@
----
-title: Rot
-permalink: wiki/Rot/
-redirect_to: /wiki/rot/
----
-
-You should automatically be redirected to [rot](/wiki/rot/)

--- a/wiki-export-alternate/Rot.mediawiki
+++ b/wiki-export-alternate/Rot.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[rot]]

--- a/wiki-export-alternate/Run.md
+++ b/wiki-export-alternate/Run.md
@@ -1,7 +1,0 @@
----
-title: Run
-permalink: wiki/Run/
-redirect_to: /wiki/run/
----
-
-You should automatically be redirected to [run](/wiki/run/)

--- a/wiki-export-alternate/Run.mediawiki
+++ b/wiki-export-alternate/Run.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[run]]

--- a/wiki-export-alternate/Saw.md
+++ b/wiki-export-alternate/Saw.md
@@ -1,7 +1,0 @@
----
-title: Saw
-permalink: wiki/Saw/
-redirect_to: /wiki/saw/
----
-
-You should automatically be redirected to [saw](/wiki/saw/)

--- a/wiki-export-alternate/Saw.mediawiki
+++ b/wiki-export-alternate/Saw.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[saw]]

--- a/wiki-export-alternate/Scale.md
+++ b/wiki-export-alternate/Scale.md
@@ -1,7 +1,0 @@
----
-title: Scale
-permalink: wiki/Scale/
-redirect_to: /wiki/scale/
----
-
-You should automatically be redirected to [scale](/wiki/scale/)

--- a/wiki-export-alternate/Scale.mediawiki
+++ b/wiki-export-alternate/Scale.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[scale]]

--- a/wiki-export-alternate/Scan.md
+++ b/wiki-export-alternate/Scan.md
@@ -1,7 +1,0 @@
----
-title: Scan
-permalink: wiki/Scan/
-redirect_to: /wiki/scan/
----
-
-You should automatically be redirected to [scan](/wiki/scan/)

--- a/wiki-export-alternate/Scan.mediawiki
+++ b/wiki-export-alternate/Scan.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[scan]]

--- a/wiki-export-alternate/Scramble.md
+++ b/wiki-export-alternate/Scramble.md
@@ -1,7 +1,0 @@
----
-title: Scramble
-permalink: wiki/Scramble/
-redirect_to: /wiki/scramble/
----
-
-You should automatically be redirected to [scramble](/wiki/scramble/)

--- a/wiki-export-alternate/Scramble.mediawiki
+++ b/wiki-export-alternate/Scramble.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[scramble]]

--- a/wiki-export-alternate/Segment.md
+++ b/wiki-export-alternate/Segment.md
@@ -1,7 +1,0 @@
----
-title: Segment
-permalink: wiki/Segment/
-redirect_to: /wiki/segment/
----
-
-You should automatically be redirected to [segment](/wiki/segment/)

--- a/wiki-export-alternate/Segment.mediawiki
+++ b/wiki-export-alternate/Segment.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[segment]]

--- a/wiki-export-alternate/SeqP.md
+++ b/wiki-export-alternate/SeqP.md
@@ -1,7 +1,0 @@
----
-title: SeqP
-permalink: wiki/SeqP/
-redirect_to: /wiki/seqP/
----
-
-You should automatically be redirected to [seqP](/wiki/seqP/)

--- a/wiki-export-alternate/SeqP.mediawiki
+++ b/wiki-export-alternate/SeqP.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[seqP]]

--- a/wiki-export-alternate/SeqPLoop.md
+++ b/wiki-export-alternate/SeqPLoop.md
@@ -1,7 +1,0 @@
----
-title: SeqPLoop
-permalink: wiki/SeqPLoop/
-redirect_to: /wiki/seqPLoop/
----
-
-You should automatically be redirected to [seqPLoop](/wiki/seqPLoop/)

--- a/wiki-export-alternate/SeqPLoop.mediawiki
+++ b/wiki-export-alternate/SeqPLoop.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[seqPLoop]]

--- a/wiki-export-alternate/Shape.md
+++ b/wiki-export-alternate/Shape.md
@@ -1,7 +1,0 @@
----
-title: Shape
-permalink: wiki/Shape/
-redirect_to: /wiki/shape/
----
-
-You should automatically be redirected to [shape](/wiki/shape/)

--- a/wiki-export-alternate/Shape.mediawiki
+++ b/wiki-export-alternate/Shape.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[shape]]

--- a/wiki-export-alternate/Shuffle.md
+++ b/wiki-export-alternate/Shuffle.md
@@ -1,7 +1,0 @@
----
-title: Shuffle
-permalink: wiki/Shuffle/
-redirect_to: /wiki/shuffle/
----
-
-You should automatically be redirected to [shuffle](/wiki/shuffle/)

--- a/wiki-export-alternate/Shuffle.mediawiki
+++ b/wiki-export-alternate/Shuffle.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[shuffle]]

--- a/wiki-export-alternate/Silence.md
+++ b/wiki-export-alternate/Silence.md
@@ -1,7 +1,0 @@
----
-title: Silence
-permalink: wiki/Silence/
-redirect_to: /wiki/silence/
----
-
-You should automatically be redirected to [silence](/wiki/silence/)

--- a/wiki-export-alternate/Silence.mediawiki
+++ b/wiki-export-alternate/Silence.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[silence]]

--- a/wiki-export-alternate/Sine.md
+++ b/wiki-export-alternate/Sine.md
@@ -1,7 +1,0 @@
----
-title: Sine
-permalink: wiki/Sine/
-redirect_to: /wiki/sine/
----
-
-You should automatically be redirected to [sine](/wiki/sine/)

--- a/wiki-export-alternate/Sine.mediawiki
+++ b/wiki-export-alternate/Sine.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[sine]]

--- a/wiki-export-alternate/Size.md
+++ b/wiki-export-alternate/Size.md
@@ -1,7 +1,0 @@
----
-title: Size
-permalink: wiki/Size/
-redirect_to: /wiki/size/
----
-
-You should automatically be redirected to [size](/wiki/size/)

--- a/wiki-export-alternate/Size.mediawiki
+++ b/wiki-export-alternate/Size.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[size]]

--- a/wiki-export-alternate/Slice.md
+++ b/wiki-export-alternate/Slice.md
@@ -1,7 +1,0 @@
----
-title: Slice
-permalink: wiki/Slice/
-redirect_to: /wiki/slice/
----
-
-You should automatically be redirected to [slice](/wiki/slice/)

--- a/wiki-export-alternate/Slice.mediawiki
+++ b/wiki-export-alternate/Slice.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[slice]]

--- a/wiki-export-alternate/Slow.md
+++ b/wiki-export-alternate/Slow.md
@@ -1,7 +1,0 @@
----
-title: Slow
-permalink: wiki/Slow/
-redirect_to: /wiki/slow/
----
-
-You should automatically be redirected to [slow](/wiki/slow/)

--- a/wiki-export-alternate/Slow.mediawiki
+++ b/wiki-export-alternate/Slow.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[slow]]

--- a/wiki-export-alternate/SlowAppend.md
+++ b/wiki-export-alternate/SlowAppend.md
@@ -1,7 +1,0 @@
----
-title: SlowAppend
-permalink: wiki/SlowAppend/
-redirect_to: /wiki/append/
----
-
-You should automatically be redirected to [append](/wiki/append/)

--- a/wiki-export-alternate/SlowAppend.mediawiki
+++ b/wiki-export-alternate/SlowAppend.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[append]]

--- a/wiki-export-alternate/Smash.md
+++ b/wiki-export-alternate/Smash.md
@@ -1,7 +1,0 @@
----
-title: Smash
-permalink: wiki/Smash/
-redirect_to: /wiki/smash/
----
-
-You should automatically be redirected to [smash](/wiki/smash/)

--- a/wiki-export-alternate/Smash.mediawiki
+++ b/wiki-export-alternate/Smash.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[smash]]

--- a/wiki-export-alternate/Sometimes.md
+++ b/wiki-export-alternate/Sometimes.md
@@ -1,7 +1,0 @@
----
-title: Sometimes
-permalink: wiki/Sometimes/
-redirect_to: /wiki/sometimes/
----
-
-You should automatically be redirected to [sometimes](/wiki/sometimes/)

--- a/wiki-export-alternate/Sometimes.mediawiki
+++ b/wiki-export-alternate/Sometimes.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[sometimes]]

--- a/wiki-export-alternate/SometimesBy.md
+++ b/wiki-export-alternate/SometimesBy.md
@@ -1,7 +1,0 @@
----
-title: SometimesBy
-permalink: wiki/SometimesBy/
-redirect_to: /wiki/sometimesBy/
----
-
-You should automatically be redirected to [sometimesBy](/wiki/sometimesBy/)

--- a/wiki-export-alternate/SometimesBy.mediawiki
+++ b/wiki-export-alternate/SometimesBy.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[sometimesBy]]

--- a/wiki-export-alternate/Sound.md
+++ b/wiki-export-alternate/Sound.md
@@ -1,7 +1,0 @@
----
-title: Sound
-permalink: wiki/Sound/
-redirect_to: /wiki/sound/
----
-
-You should automatically be redirected to [sound](/wiki/sound/)

--- a/wiki-export-alternate/Sound.mediawiki
+++ b/wiki-export-alternate/Sound.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[sound]]

--- a/wiki-export-alternate/Sparsity.md
+++ b/wiki-export-alternate/Sparsity.md
@@ -1,7 +1,0 @@
----
-title: Sparsity
-permalink: wiki/Sparsity/
-redirect_to: /wiki/slow/
----
-
-You should automatically be redirected to [slow](/wiki/slow/)

--- a/wiki-export-alternate/Sparsity.mediawiki
+++ b/wiki-export-alternate/Sparsity.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[slow]]

--- a/wiki-export-alternate/Speed.md
+++ b/wiki-export-alternate/Speed.md
@@ -1,7 +1,0 @@
----
-title: Speed
-permalink: wiki/Speed/
-redirect_to: /wiki/speed/
----
-
-You should automatically be redirected to [speed](/wiki/speed/)

--- a/wiki-export-alternate/Speed.mediawiki
+++ b/wiki-export-alternate/Speed.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[speed]]

--- a/wiki-export-alternate/Spin.md
+++ b/wiki-export-alternate/Spin.md
@@ -1,7 +1,0 @@
----
-title: Spin
-permalink: wiki/Spin/
-redirect_to: /wiki/spin/
----
-
-You should automatically be redirected to [spin](/wiki/spin/)

--- a/wiki-export-alternate/Spin.mediawiki
+++ b/wiki-export-alternate/Spin.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[spin]]

--- a/wiki-export-alternate/Square.md
+++ b/wiki-export-alternate/Square.md
@@ -1,7 +1,0 @@
----
-title: Square
-permalink: wiki/Square/
-redirect_to: /wiki/square/
----
-
-You should automatically be redirected to [square](/wiki/square/)

--- a/wiki-export-alternate/Square.mediawiki
+++ b/wiki-export-alternate/Square.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[square]]

--- a/wiki-export-alternate/Squiz.md
+++ b/wiki-export-alternate/Squiz.md
@@ -1,7 +1,0 @@
----
-title: Squiz
-permalink: wiki/Squiz/
-redirect_to: /wiki/squiz/
----
-
-You should automatically be redirected to [squiz](/wiki/squiz/)

--- a/wiki-export-alternate/Squiz.mediawiki
+++ b/wiki-export-alternate/Squiz.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[squiz]]

--- a/wiki-export-alternate/Stack.md
+++ b/wiki-export-alternate/Stack.md
@@ -1,7 +1,0 @@
----
-title: Stack
-permalink: wiki/Stack/
-redirect_to: /wiki/stack/
----
-
-You should automatically be redirected to [stack](/wiki/stack/)

--- a/wiki-export-alternate/Stack.mediawiki
+++ b/wiki-export-alternate/Stack.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[stack]]

--- a/wiki-export-alternate/Striate.md
+++ b/wiki-export-alternate/Striate.md
@@ -1,7 +1,0 @@
----
-title: Striate
-permalink: wiki/Striate/
-redirect_to: /wiki/striate/
----
-
-You should automatically be redirected to [striate](/wiki/striate/)

--- a/wiki-export-alternate/Striate.mediawiki
+++ b/wiki-export-alternate/Striate.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[striate]]

--- a/wiki-export-alternate/StriateBy.md
+++ b/wiki-export-alternate/StriateBy.md
@@ -1,7 +1,0 @@
----
-title: StriateBy
-permalink: wiki/StriateBy/
-redirect_to: /wiki/striateBy/
----
-
-You should automatically be redirected to [striateBy](/wiki/striateBy/)

--- a/wiki-export-alternate/StriateBy.mediawiki
+++ b/wiki-export-alternate/StriateBy.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[striateBy]]

--- a/wiki-export-alternate/Stripe.md
+++ b/wiki-export-alternate/Stripe.md
@@ -1,7 +1,0 @@
----
-title: Stripe
-permalink: wiki/Stripe/
-redirect_to: /wiki/stripe/
----
-
-You should automatically be redirected to [stripe](/wiki/stripe/)

--- a/wiki-export-alternate/Stripe.mediawiki
+++ b/wiki-export-alternate/Stripe.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[stripe]]

--- a/wiki-export-alternate/Struct.md
+++ b/wiki-export-alternate/Struct.md
@@ -1,7 +1,0 @@
----
-title: Struct
-permalink: wiki/Struct/
-redirect_to: /wiki/struct/
----
-
-You should automatically be redirected to [struct](/wiki/struct/)

--- a/wiki-export-alternate/Struct.mediawiki
+++ b/wiki-export-alternate/Struct.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[struct]]

--- a/wiki-export-alternate/Stut.md
+++ b/wiki-export-alternate/Stut.md
@@ -1,7 +1,0 @@
----
-title: Stut
-permalink: wiki/Stut/
-redirect_to: /wiki/stut/
----
-
-You should automatically be redirected to [stut](/wiki/stut/)

--- a/wiki-export-alternate/Stut.mediawiki
+++ b/wiki-export-alternate/Stut.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[stut]]

--- a/wiki-export-alternate/StutWith.md
+++ b/wiki-export-alternate/StutWith.md
@@ -1,7 +1,0 @@
----
-title: StutWith
-permalink: wiki/StutWith/
-redirect_to: /wiki/stutWith/
----
-
-You should automatically be redirected to [stutWith](/wiki/stutWith/)

--- a/wiki-export-alternate/StutWith.mediawiki
+++ b/wiki-export-alternate/StutWith.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[stutWith]]

--- a/wiki-export-alternate/Superimpose.md
+++ b/wiki-export-alternate/Superimpose.md
@@ -1,7 +1,0 @@
----
-title: Superimpose
-permalink: wiki/Superimpose/
-redirect_to: /wiki/superimpose/
----
-
-You should automatically be redirected to [superimpose](/wiki/superimpose/)

--- a/wiki-export-alternate/Superimpose.mediawiki
+++ b/wiki-export-alternate/Superimpose.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[superimpose]]

--- a/wiki-export-alternate/Swing.md
+++ b/wiki-export-alternate/Swing.md
@@ -1,7 +1,0 @@
----
-title: Swing
-permalink: wiki/Swing/
-redirect_to: /wiki/swing/
----
-
-You should automatically be redirected to [swing](/wiki/swing/)

--- a/wiki-export-alternate/Swing.mediawiki
+++ b/wiki-export-alternate/Swing.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[swing]]

--- a/wiki-export-alternate/SwingBy.md
+++ b/wiki-export-alternate/SwingBy.md
@@ -1,7 +1,0 @@
----
-title: SwingBy
-permalink: wiki/SwingBy/
-redirect_to: /wiki/swingBy/
----
-
-You should automatically be redirected to [swingBy](/wiki/swingBy/)

--- a/wiki-export-alternate/SwingBy.mediawiki
+++ b/wiki-export-alternate/SwingBy.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[swingBy]]

--- a/wiki-export-alternate/Tri.md
+++ b/wiki-export-alternate/Tri.md
@@ -1,7 +1,0 @@
----
-title: Tri
-permalink: wiki/Tri/
-redirect_to: /wiki/tri/
----
-
-You should automatically be redirected to [tri](/wiki/tri/)

--- a/wiki-export-alternate/Tri.mediawiki
+++ b/wiki-export-alternate/Tri.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[tri]]

--- a/wiki-export-alternate/Trunc.md
+++ b/wiki-export-alternate/Trunc.md
@@ -1,7 +1,0 @@
----
-title: Trunc
-permalink: wiki/Trunc/
-redirect_to: /wiki/trunc/
----
-
-You should automatically be redirected to [trunc](/wiki/trunc/)

--- a/wiki-export-alternate/Trunc.mediawiki
+++ b/wiki-export-alternate/Trunc.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[trunc]]

--- a/wiki-export-alternate/Ur.md
+++ b/wiki-export-alternate/Ur.md
@@ -1,7 +1,0 @@
----
-title: Ur
-permalink: wiki/Ur/
-redirect_to: /wiki/ur/
----
-
-You should automatically be redirected to [ur](/wiki/ur/)

--- a/wiki-export-alternate/Ur.mediawiki
+++ b/wiki-export-alternate/Ur.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[ur]]

--- a/wiki-export-alternate/Vowel.md
+++ b/wiki-export-alternate/Vowel.md
@@ -1,7 +1,0 @@
----
-title: Vowel
-permalink: wiki/Vowel/
-redirect_to: /wiki/vowel/
----
-
-You should automatically be redirected to [vowel](/wiki/vowel/)

--- a/wiki-export-alternate/Vowel.mediawiki
+++ b/wiki-export-alternate/Vowel.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[vowel]]

--- a/wiki-export-alternate/Waveloss.md
+++ b/wiki-export-alternate/Waveloss.md
@@ -1,7 +1,0 @@
----
-title: Waveloss
-permalink: wiki/Waveloss/
-redirect_to: /wiki/waveloss/
----
-
-You should automatically be redirected to [waveloss](/wiki/waveloss/)

--- a/wiki-export-alternate/Waveloss.mediawiki
+++ b/wiki-export-alternate/Waveloss.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[waveloss]]

--- a/wiki-export-alternate/Wchoose.md
+++ b/wiki-export-alternate/Wchoose.md
@@ -1,7 +1,0 @@
----
-title: Wchoose
-permalink: wiki/Wchoose/
-redirect_to: /wiki/wchoose/
----
-
-You should automatically be redirected to [wchoose](/wiki/wchoose/)

--- a/wiki-export-alternate/Wchoose.mediawiki
+++ b/wiki-export-alternate/Wchoose.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[wchoose]]

--- a/wiki-export-alternate/WchooseBy.md
+++ b/wiki-export-alternate/WchooseBy.md
@@ -1,7 +1,0 @@
----
-title: WchooseBy
-permalink: wiki/WchooseBy/
-redirect_to: /wiki/wchooseBy/
----
-
-You should automatically be redirected to [wchooseBy](/wiki/wchooseBy/)

--- a/wiki-export-alternate/WchooseBy.mediawiki
+++ b/wiki-export-alternate/WchooseBy.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[wchooseBy]]

--- a/wiki-export-alternate/Weave.md
+++ b/wiki-export-alternate/Weave.md
@@ -1,7 +1,0 @@
----
-title: Weave
-permalink: wiki/Weave/
-redirect_to: /wiki/weave/
----
-
-You should automatically be redirected to [weave](/wiki/weave/)

--- a/wiki-export-alternate/Weave.mediawiki
+++ b/wiki-export-alternate/Weave.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[weave]]

--- a/wiki-export-alternate/WeaveWith.md
+++ b/wiki-export-alternate/WeaveWith.md
@@ -1,7 +1,0 @@
----
-title: WeaveWith
-permalink: wiki/WeaveWith/
-redirect_to: /wiki/weaveWith/
----
-
-You should automatically be redirected to [weaveWith](/wiki/weaveWith/)

--- a/wiki-export-alternate/WeaveWith.mediawiki
+++ b/wiki-export-alternate/WeaveWith.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[weaveWith]]

--- a/wiki-export-alternate/Wedge.md
+++ b/wiki-export-alternate/Wedge.md
@@ -1,7 +1,0 @@
----
-title: Wedge
-permalink: wiki/Wedge/
-redirect_to: /wiki/wedge/
----
-
-You should automatically be redirected to [wedge](/wiki/wedge/)

--- a/wiki-export-alternate/Wedge.mediawiki
+++ b/wiki-export-alternate/Wedge.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[wedge]]

--- a/wiki-export-alternate/When.md
+++ b/wiki-export-alternate/When.md
@@ -1,7 +1,0 @@
----
-title: When
-permalink: wiki/When/
-redirect_to: /wiki/when/
----
-
-You should automatically be redirected to [when](/wiki/when/)

--- a/wiki-export-alternate/When.mediawiki
+++ b/wiki-export-alternate/When.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[when]]

--- a/wiki-export-alternate/Whenmod.md
+++ b/wiki-export-alternate/Whenmod.md
@@ -1,7 +1,0 @@
----
-title: Whenmod
-permalink: wiki/Whenmod/
-redirect_to: /wiki/whenmod/
----
-
-You should automatically be redirected to [whenmod](/wiki/whenmod/)

--- a/wiki-export-alternate/Whenmod.mediawiki
+++ b/wiki-export-alternate/Whenmod.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[whenmod]]

--- a/wiki-export-alternate/Within.md
+++ b/wiki-export-alternate/Within.md
@@ -1,7 +1,0 @@
----
-title: Within
-permalink: wiki/Within/
-redirect_to: /wiki/within/
----
-
-You should automatically be redirected to [within](/wiki/within/)

--- a/wiki-export-alternate/Within.mediawiki
+++ b/wiki-export-alternate/Within.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[within]]

--- a/wiki-export-alternate/Zoom.md
+++ b/wiki-export-alternate/Zoom.md
@@ -1,7 +1,0 @@
----
-title: Zoom
-permalink: wiki/Zoom/
-redirect_to: /wiki/zoom/
----
-
-You should automatically be redirected to [zoom](/wiki/zoom/)

--- a/wiki-export-alternate/Zoom.mediawiki
+++ b/wiki-export-alternate/Zoom.mediawiki
@@ -1,1 +1,0 @@
-#REDIRECT [[zoom]]


### PR DESCRIPTION
(take 2) This affected @Bubobubobubobubo on an apple/afs filesystem, and will affect any windows users too I believe.
Files with identical names other than case sensitivity are not able to exist in the same directory, git throws a huge number of errors and leaves the duplicate files in a funky state when checkout on this type of fs is attempted.

I diff'd the duplicates (there were no differences), then just deleted one of them.

The bash I used to cleanup:

```
find ./ -type f | while read line; do 
  n=$(find ./ -iname $(basename "${line}") | wc -l); 
  if [ ${n} -eq 2 ]; then 
    git rm $(find ./ -iname $(basename "${line}") | sort | tail -n 1); 
  fi ; 
done
```