### PR TITLE
Update SuperCollider download URL

### DIFF
--- a/docs/getting-started/MacOS_installation.md
+++ b/docs/getting-started/MacOS_installation.md
@@ -20,7 +20,7 @@ Before installing Tidal, make sure the following are installed first:
 -   [Atom Editor](https://atom.io/) (if you don't like the atom editor
     for some reason, please check out the [list of
     alternatives](/wiki/List_of_tidal_editors "wikilink"))
--   [SuperCollider](http://supercollider.github.io/download) (pick the
+-   [SuperCollider](https://supercollider.github.io/downloads) (pick the
     latest version)
 -   [Git](https://git-scm.com/)
 

--- a/docs/getting-started/Windows_installation.md
+++ b/docs/getting-started/Windows_installation.md
@@ -30,7 +30,7 @@ Before installing Tidal, make sure the following are installed first:
 -   [Atom Editor](https://atom.io/) (if you don't like the atom editor
     for some reason, please check out the [list of
     alternatives](/wiki/List_of_tidal_editors "wikilink"))
--   [SuperCollider](http://supercollider.github.io/download) (pick the
+-   [SuperCollider](https://supercollider.github.io/downloads) (pick the
     latest version)
 -   [Git](https://git-scm.com/)
 

--- a/docs/getting-started/linux_install.md
+++ b/docs/getting-started/linux_install.md
@@ -18,7 +18,7 @@ There are user-made guides to install Tidal Cycles. Be sure to check out the fol
 
 ## Manual installation
 
-You need to install several components to get a complete Tidal Cycles system ([Git](https://git-scm.com/), [Haskell](https://www.haskell.org/platform/), [SuperCollider](http://supercollider.github.io/download) and [SuperDirt](https://github.com/musikinformatik/SuperDirt)). Hopefully, your Linux distribution makes the pre-requisites easily available to you via a package manager. You will also need a text editor. Check the sidebar to get a list of supported editors along with instructions for setting them up.
+You need to install several components to get a complete Tidal Cycles system ([Git](https://git-scm.com/), [Haskell](https://www.haskell.org/platform/), [SuperCollider](https://supercollider.github.io/downloads) and [SuperDirt](https://github.com/musikinformatik/SuperDirt)). Hopefully, your Linux distribution makes the pre-requisites easily available to you via a package manager. You will also need a text editor. Check the sidebar to get a list of supported editors along with instructions for setting them up.
 
 
 If your distribution comes with the `apt` package manager (Debian family), you can install some of these dependencies using the following command:

--- a/docs/getting-started/macos_install.md
+++ b/docs/getting-started/macos_install.md
@@ -31,7 +31,7 @@ installs them if they are missing.
 
 ## Manual installation
 
-Before installing Tidal, make sure to install [Haskell](https://www.haskell.org/ghcup/) (via [Ghcup](https://www.haskell.org/ghcup/)), [SuperCollider](http://supercollider.github.io/downloads) with  [SC3 Plugins](https://supercollider.github.io/sc3-plugins/),   [Git](https://git-scm.com/). You also need to choose and install a text editor for interacting with Tidal Cycles (see the sidebar).
+Before installing Tidal, make sure to install [Haskell](https://www.haskell.org/ghcup/) (via [Ghcup](https://www.haskell.org/ghcup/)), [SuperCollider](https://supercollider.github.io/downloadss) with  [SC3 Plugins](https://supercollider.github.io/sc3-plugins/),   [Git](https://git-scm.com/). You also need to choose and install a text editor for interacting with Tidal Cycles (see the sidebar).
 
 ### Installation process
 

--- a/docs/getting-started/windows_install.md
+++ b/docs/getting-started/windows_install.md
@@ -47,7 +47,7 @@ choco install tidalcycles
 
 ## Manual installation
 
-You might prefer to install the different components of Tidal Cycles by hand. This is the recommand way for users who already installed some of the components ([Git](https://git-scm.com/), [Haskell](https://www.haskell.org/ghcup/), [Atom Editor](https://atom.io/), [SuperCollider](http://supercollider.github.io/download), [SuperDirt](https://github.com/musikinformatik/SuperDirt)). All these components are needed to install Tidal Cycles.
+You might prefer to install the different components of Tidal Cycles by hand. This is the recommand way for users who already installed some of the components ([Git](https://git-scm.com/), [Haskell](https://www.haskell.org/ghcup/), [Atom Editor](https://atom.io/), [SuperCollider](https://supercollider.github.io/downloads), [SuperDirt](https://github.com/musikinformatik/SuperDirt)). All these components are needed to install Tidal Cycles.
 
 ### SC3 Plugins
 


### PR DESCRIPTION
The old URL does not work.

By the way, is docs/getting-started/Windows_installation.md still relevant or should it be removed? It does not seem findable from navigation?