### PR TITLE
Some missing functions + tidying up randomness and conditionals

### DIFF
--- a/docs/reference/conditions.md
+++ b/docs/reference/conditions.md
@@ -66,7 +66,17 @@ The above will only apply striate `4` to the pattern if the current cycle number
 
 ### whenT
 
-This function is not documented.
+```haskell
+Type: whenT :: (Time -> Bool) -> (Pattern a -> Pattern a) ->  Pattern a -> Pattern a
+```
+
+Only when the given test function returns `True` the given pattern transformation is applied. It differs from `when`, being passed a continuous `Time` value instead of the cycle number. Basically, a `Rational` version of `when`.
+
+```haskell
+d1 $ whenT ((< 0.5).(flip Data.Fixed.mod' 2)) (# speed 2) $ sound "hh(4,8) hc(3,8)"
+```
+
+The above will apply `# speed 2` only when the remainder of the current `Time` divided by `2` is less than `0.5`.
 
 ### whenmod
 

--- a/docs/reference/conditions.md
+++ b/docs/reference/conditions.md
@@ -298,6 +298,23 @@ squeeze :: Pattern Int -> [Pattern a] -> Pattern a
 ```
 Chooses between a list of patterns, using a pattern of integers.
 
+### inhabit
+
+```haskell
+inhabit :: [(String, Pattern a)] -> Pattern String -> Pattern a
+```
+`inhabit` allows you to link patterns to some String, or in other words, to give patterns a name and then call them from within another pattern of Strings.
+
+For example, we may make our own bassdrum, hi-hat and snaredrum kit using tidal:
+
+```haskell
+do
+  let drum = inhabit [("bd",s "sine" |- accelerate 1.5),("hh",s "alphabet:7" # begin 0.7 # hpf 7000),("sd",s "invaders:3" # speed 12)]
+  d1 $ drum "[bd*8?, [~hh]*4, sd(6,16)]"
+```
+
+`inhabit` can be very useful when using MIDI controlled drum machines, since you can give understandable drum names to patterns of notes.
+
 ## Euclidians
 
 ### euclid

--- a/docs/reference/conditions.md
+++ b/docs/reference/conditions.md
@@ -425,7 +425,18 @@ If you listen to this you'll hear that which instrument is shifted up and which 
 
 ### contrastBy
 
-`contrastBy` is currently undocumented.
+```haskell
+Type: contrastBy :: (a -> Value -> Bool) -> (ControlPattern -> Pattern b) -> (ControlPattern -> Pattern b) -> Pattern (Map.Map String a) -> Pattern (Map.Map String Value) -> Pattern b
+```
+`contrastBy` is a more general version of `contrast` where you can specify an abritrary boolean function that will be used to compare the control patterns. For example, `contrast` itself is defined as `contrastBy (==)`, to test for equality.
+
+Compare the following:
+```haskell
+d1 $ contrast (|+ n 12) (|- n 12) (n "2") $ n "0 1 2 [3 4]" # s "superpiano"
+
+d2 $ contrastBy (>=) (|+ n 12) (|- n 12) (n "2") $ n "0 1 2 [3 4]" # s "superpiano"
+```
+In the latter example, we test for "greater than or equals to" instead of simple equality.
 
 ## ifp
 

--- a/docs/reference/conditions.md
+++ b/docs/reference/conditions.md
@@ -9,7 +9,7 @@ This page will present you all the functions that can be used to add conditions 
 * **Examples**: a small list of examples that you can copy/paste in your editor.
 
 
-## Conditions on cycles
+## Conditions on cycle numbers
 
 ### every
 ```haskell
@@ -268,7 +268,7 @@ Type: Pattern Bool -> Pattern a -> Pattern a -> Pattern a
 d1 $ ccv (stitch "t(7,16)" 127 0) # ccn 0  # "midi"
 ```
 
-## Choosing patterns
+## Choosing patterns and functions
 
 ### select
 

--- a/docs/reference/randomness.md
+++ b/docs/reference/randomness.md
@@ -83,3 +83,117 @@ d1
  # lpf (range 60 5000 $ perlin2With (cosine*2) (sine*2))
  # lpq 0.3
 ```
+
+## The "sometimes" family
+
+### sometimes
+
+```haskell
+Type: sometimes :: (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+```
+
+`sometimes` is function, that applies another function to a pattern, around 50% of the time, at random. It takes two inputs, the function to be applied, and the pattern you are applying it to.
+
+For example to distort half the events in a pattern:
+```haskell
+d1 $ sometimes (# crush 2) $ n "0 1 [~ 2] 3" # sound "arpy"
+```
+
+`sometimes` has a number of variants, which apply the function with different likelihood: 
+
+| function     |  likelihood |
+|--------------|-------------|
+| always       | 100%        |
+| almostAlways | 90%         |
+| often        | 75%         |
+| sometimes    | 50%         |
+| rarely       | 25%         |
+| almostNever  | 10%         |
+| never        | 0%          |
+
+
+### sometimesBy
+
+If you want to be specific, you can use `sometimesBy` and a number, for example:
+```haskell
+sometimesBy 0.93 (# speed 2)
+```
+
+to apply the speed control on average 93 times out of a hundred.
+
+
+### someCycles
+
+`someCycles` is similar to `sometimes`, but instead of applying the given function to random events, it applies it to random cycles. For example the following will either distort all of the events in a cycle, or none of them:
+
+```haskell
+d1 $ someCycles (# crush 2) $ n "0 1 [~ 2] 3" # sound "arpy"
+```
+
+### someCyclesBy
+
+As with `sometimesBy`, if you want to be specific, you can use `someCyclesBy` and a number. For example:
+
+```haskell
+someCyclesBy 0.93 (# speed 2)
+```
+
+will apply the speed control on average `93` cycles out of a hundred.
+
+## Choosing randomly
+
+### choose
+```haskell
+Type: choose :: [a] -> Pattern a
+```
+The `choose` function emits a stream of randomly choosen values from the given list, as a continuous pattern:
+```haskell
+d1 $ sound "drum ~ drum drum" # n (choose [0,2,3])
+```
+
+As with all continuous patterns, you have to be careful to give them structure; in this case choose gives you an infinitely detailed stream of random choices. 
+
+### chooseby
+
+```haskell
+Type: chooseBy :: Pattern Double -> [a] -> Pattern a
+```
+The `chooseBy` function is like choose but instead of selecting elements of the list randomly, it uses the given pattern to select elements.
+```haskell
+chooseBy "0 0.25 0.5" ["a","b","c","d"]
+```
+will result in the pattern `"a b c" `.
+
+### wchoose
+
+```haskell
+Type: wchoose :: [(a, Double)] -> Pattern a
+```
+
+`wchoose` is similar to `choose`, but allows you to 'weight' the choices, so some are more likely to be chosen than others. The following is similar to the previous example, but the `2` is twice as likely to be chosen than the `0` or `3`.
+
+```haskell
+d1 $ sound "drum ~ drum drum" # n (wchoose [(0,0.25),(2,0.5),(3,0.25)])
+```
+:::caution
+Prior to version `1.0.0` of **Tidal**, the weights had to add up to `1`, but this is no longer the case. 
+:::
+
+### wchooseby
+
+```haskell
+Type: wchooseBy :: Pattern Double -> [(a,Double)] -> Pattern a
+```
+
+The `wchooseBy` function is like `wchoose` but instead of selecting elements of the list randomly, it uses the given pattern to select elements. 
+
+### cycleChoose
+
+```haskell
+Type: cycleChoose :: [a] -> Pattern a
+```
+
+Similar to `choose`, but only picks once per cycle:
+```haskell
+d1 $ sound "drum ~ drum drum" # n (cycleChoose [0,2,3])
+```

--- a/docs/reference/time.md
+++ b/docs/reference/time.md
@@ -207,6 +207,26 @@ Or, to apply `(# speed "0.5")` to only the last quarter of a pattern:
 d1 $ within (0.75, 1) (# speed "0.5") $ sound "bd*2 sn lt mt hh hh hh hh"
 ```
 
+### stretch
+
+```haskell
+Type: stretch :: Pattern a -> Pattern a
+```
+
+Stretch takes a pattern, and if there's silences at the start or end of the current cycle, it will zoom in to avoid them.
+
+```haskell
+d1 $ note (stretch "~ 0 1 5 8*4 ~") # s "superpiano"
+-- is the same as
+d1 $ note "0 1 5 8*4" # s "superpiano"
+```
+
+You can pattern silences on the extremes of a cycle to make changes to the rhythm:
+
+```haskell
+d1 $ note (stretch "~ <0 ~> 1 5 8*4 ~") # s "superpiano"
+```
+
 ## Shifting time
 
 


### PR DESCRIPTION
Documents whenT, contrastBy, stretch (which IMHO should be renamed in future tidal versions to avoid confusion with the stretch sampler), and inhabit

Moves stuff from conditionals and randomness to make categories make more sense. 
The "choose family" category has been moved to the randomness page.
On conditionals:
New category "conditions on control patterns" that include both fix, unfix, contrast and etc. 
New category "choosing patterns and functions" inside conditionals, related to choosing from a list of patterns or functions, for example select, selectF, etc.
The "every and the others" category has been renamed to "Conditions on cycle numbers" and now includes ifp.
The category "Boolean conditions" now only includes functions that take Pattern Bool as input.
New "Euclidians" category to include only euclidian pattern related functions.