### PR TITLE
Update documentation to reflect required linux permissions

### DIFF
--- a/docs/getting-started/linux_install.md
+++ b/docs/getting-started/linux_install.md
@@ -68,7 +68,7 @@ sudo apt update; sudo apt install git jackd2 qjackctl zlib1g-dev gcc g++ cabal-i
 
 ***arch***
 ```bash
-sudo pacman -Syu; pacman -Sy git jack2 qjackctl
+sudo pacman -Syu; sudo pacman -Sy git jack2 qjackctl
 ```
 
 ***fedora***


### PR DESCRIPTION
sudo need's to be applied to ```pacman -Sy git jack2 qjackctl```, otherwise it will only refresh the pacman database, but not install the desired packages due to lack of permissions.