### PR TITLE
Add about.md for Tidal blog

### DIFF
--- a/blog/about.md
+++ b/blog/about.md
@@ -1,0 +1,28 @@
+---
+title: Tidal Blog Info
+date: 2023-01-01
+---
+
+## Purpose
+The Tidal Cycles blog is intended to be **by -- for -- about** the Tidal community.
+Anyone engaged with Tidal Cycles is encouraged to submit a blog post. Topics can be about Tidal practices, music made with Tidal, live coding, event coverage, new developments & releases, community, etc. Topics can also be broader -- anything that would be of interest to this community and it doesn't have to be limited to just about Tidal!
+
+## Templates
+To make participation and submitting posts easier, there are a set if prepared templates. These also reflect a set of patterned submissions. Each template includes a suggested set of content sections, but consider this just a starting point. The most important thing is to provide content that reflects your unique perspective.
+
+Templates are maintained in GitHub in the [tidalcycles/tidal-doc](https://github.com/tidalcycles/tidal-doc/) repo / templates branch.
+
+- [Tidal Blog Profile](https://github.com/tidalcycles/tidal-doc/blob/templates/templates/blog_tidal_profile.md) - intended to highlight your livecoding practices, music, and use of tidal. Contains a set of questions to respond to.
+- [Tidal music](https://github.com/tidalcycles/tidal-doc/blob/templates/templates/blog_tidal_music.md) - use this to describe a music project such as a new album or music release, a review of a music project, Algorave or concert, or discussion of music made with Tidal or other live coding program.
+- Event coverage (planned)
+- [Blog Topic](https://github.com/tidalcycles/tidal-doc/blob/templates/templates/blog_topic.md) - Open topic. Use this for a more free-form approach. One option is to present your own approach to Tidal and live coding (see [Working with Samples the Heavy Lifting way](https://tidalcycles.org/blog/tidal_profile_heavylifting)). Other topics could be discussion of a new release and the coding behind it, or discussion of other environments like Strudel, Vortex, Sardine, etc.
+
+We encourage posts to include:
+- code sections with Tidal examples
+- links into the Tidal user documentation
+- links to recordings, YouTube, Bandcamp, SoundCloud, etc.
+
+## Submission Instructions
+Detailed posting instructions are included with the template files. As a summary, if you are able to work with a pull request in GitHub, use that method. Alternatively, work with a blog editor and send your content via Discord DM or email. Do what works for you!
+
+Adding your content in markdown format is preferred, but it is not required. If you aren't familiar with markdown, no problem. Write your content and we'll take care of the rest. 

--- a/blog/about.md
+++ b/blog/about.md
@@ -5,17 +5,17 @@ date: 2023-01-01
 
 ## Purpose
 The Tidal Cycles blog is intended to be **by -- for -- about** the Tidal community.
-Anyone engaged with Tidal Cycles is encouraged to submit a blog post. Topics can be about Tidal practices, music made with Tidal, live coding, event coverage, new developments & releases, community, etc. Topics can also be broader -- anything that would be of interest to this community and it doesn't have to be limited to just about Tidal!
+Anyone engaged with Tidal Cycles is encouraged to submit a blog post. Topics can be about Tidal practices, music made with Tidal, live coding, event coverage, new developments & releases, community, etc. Topics can also be broader -- anything that would be of interest to this community, and it doesn't have to be limited to just about Tidal!
 
 ## Templates
-To make participation and submitting posts easier, there are a set if prepared templates. These also reflect a set of patterned submissions. Each template includes a suggested set of content sections, but consider this just a starting point. The most important thing is to provide content that reflects your unique perspective.
+To make participation and submitting posts easier, there are a set if templates. These produce a set of patterned blog posts. Each template includes a suggested set of content sections, but consider this just a starting point. The most important thing is to provide content that reflects your unique perspective.
 
 Templates are maintained in GitHub in the [tidalcycles/tidal-doc](https://github.com/tidalcycles/tidal-doc/) repo / templates branch.
 
-- [Tidal Blog Profile](https://github.com/tidalcycles/tidal-doc/blob/templates/templates/blog_tidal_profile.md) - intended to highlight your livecoding practices, music, and use of tidal. Contains a set of questions to respond to.
-- [Tidal music](https://github.com/tidalcycles/tidal-doc/blob/templates/templates/blog_tidal_music.md) - use this to describe a music project such as a new album or music release, a review of a music project, Algorave or concert, or discussion of music made with Tidal or other live coding program.
+- [Tidal Blog Profile](https://github.com/tidalcycles/tidal-doc/blob/templates/templates/blog_tidal_profile.md) Intended to highlight your livecoding practices, music, and use of tidal. Contains a set of questions to respond to.
+- [Tidal music](https://github.com/tidalcycles/tidal-doc/blob/templates/templates/blog_tidal_music.md) Use this to describe a music project such as a new album or music release, a review of a music project, Algorave or concert, or discussion of music made with Tidal or other live coding program.
 - Event coverage (planned)
-- [Blog Topic](https://github.com/tidalcycles/tidal-doc/blob/templates/templates/blog_topic.md) - Open topic. Use this for a more free-form approach. One option is to present your own approach to Tidal and live coding (see [Working with Samples the Heavy Lifting way](https://tidalcycles.org/blog/tidal_profile_heavylifting)). Other topics could be discussion of a new release and the coding behind it, or discussion of other environments like Strudel, Vortex, Sardine, etc.
+- [Blog Topic](https://github.com/tidalcycles/tidal-doc/blob/templates/templates/blog_topic.md) Open topic - use this for a more free-form approach. One option is to present your own approach to Tidal and live coding (see [Working with Samples the Heavy Lifting way](https://tidalcycles.org/blog/tidal_profile_heavylifting)). Other topics could be discussion of a new release and the coding behind it, or discussion of other environments like Strudel, Vortex, Sardine, etc.
 
 We encourage posts to include:
 - code sections with Tidal examples
@@ -23,6 +23,10 @@ We encourage posts to include:
 - links to recordings, YouTube, Bandcamp, SoundCloud, etc.
 
 ## Submission Instructions
-Detailed posting instructions are included with the template files. As a summary, if you are able to work with a pull request in GitHub, use that method. Alternatively, work with a blog editor and send your content via Discord DM or email. Do what works for you!
+Detailed posting instructions are included in the template files. Options:
+- Submit via GitHub pull request
+- Work with a blog editor and send your content via Discord DM or email.
 
-Adding your content in markdown format is preferred, but it is not required. If you aren't familiar with markdown, no problem. Write your content and we'll take care of the rest. 
+Do what works for you!
+
+Adding your content in markdown format is preferred, but it is not required. If you aren't familiar with markdown, no problem. Write your content and we'll take care of the rest.


### PR DESCRIPTION
The Tidal Blog info page describes the purpose of the Tidal blog and includes links to the templates and submissions instructions. 