### PR TITLE
Update `BootTidal.hs` and use Haskell syntax highlighting

### DIFF
--- a/docs/configuration/boottidal.md
+++ b/docs/configuration/boottidal.md
@@ -8,7 +8,7 @@ Everytime you start Tidal, the software is reading from a configuration file usu
 Some users went really far into customizing their setup: [Jarmlib](https://github.com/jarmitage/jarmlib). You can take a look at their work to see how to extend your configuration file.
 
 As an example, here is the *vanilla* `BootTidal.hs` file used by the [Pulsar Package for Tidal](https://raw.githubusercontent.com/tidalcycles/pulsar-tidalcycles/master/lib/BootTidal.hs):
-```c
+```haskell
 :set -XOverloadedStrings
 :set prompt ""
 

--- a/docs/configuration/boottidal.md
+++ b/docs/configuration/boottidal.md
@@ -13,18 +13,23 @@ As an example, here is the *vanilla* `BootTidal.hs` file used by the [Pulsar Pac
 :set prompt ""
 
 import Sound.Tidal.Context
+
 import System.IO (hSetEncoding, stdout, utf8)
 hSetEncoding stdout utf8
 
--- total latency = oLatency + cFrameTimespan
-tidal <- startTidal (superdirtTarget {oLatency = 0.1, oAddress = "127.0.0.1", oPort = 57120}) (defaultConfig {cFrameTimespan = 1/20})
+tidal <- startTidal (superdirtTarget {oLatency = 0.05, oAddress = "127.0.0.1", oPort = 57120}) (defaultConfig {cVerbose = True, cFrameTimespan = 1/20})
 
 :{
-let p = streamReplace tidal
+let only = (hush >>)
+    p = streamReplace tidal
     hush = streamHush tidal
+    panic = do hush
+               once $ sound "superpanic"
     list = streamList tidal
     mute = streamMute tidal
     unmute = streamUnmute tidal
+    unmuteAll = streamUnmuteAll tidal
+    unsoloAll = streamUnsoloAll tidal
     solo = streamSolo tidal
     unsolo = streamUnsolo tidal
     once = streamOnce tidal
@@ -33,7 +38,10 @@ let p = streamReplace tidal
     nudgeAll = streamNudgeAll tidal
     all = streamAll tidal
     resetCycles = streamResetCycles tidal
+    setCycle = streamSetCycle tidal
     setcps = asap . cps
+    getcps = streamGetcps tidal
+    getnow = streamGetnow tidal
     xfade i = transition tidal True (Sound.Tidal.Transition.xfadeIn 4) i
     xfadeIn i t = transition tidal True (Sound.Tidal.Transition.xfadeIn t) i
     histpan i t = transition tidal True (Sound.Tidal.Transition.histpan t) i
@@ -43,6 +51,7 @@ let p = streamReplace tidal
     jumpIn i t = transition tidal True (Sound.Tidal.Transition.jumpIn t) i
     jumpIn' i t = transition tidal True (Sound.Tidal.Transition.jumpIn' t) i
     jumpMod i t = transition tidal True (Sound.Tidal.Transition.jumpMod t) i
+    jumpMod' i t p = transition tidal True (Sound.Tidal.Transition.jumpMod' t p) i
     mortal i lifespan release = transition tidal True (Sound.Tidal.Transition.mortal lifespan release) i
     interpolate i = transition tidal True (Sound.Tidal.Transition.interpolate) i
     interpolateIn i t = transition tidal True (Sound.Tidal.Transition.interpolateIn t) i
@@ -70,7 +79,8 @@ let p = streamReplace tidal
 :}
 
 :{
-let setI = streamSetI tidal
+let getState = streamGet tidal
+    setI = streamSetI tidal
     setF = streamSetF tidal
     setS = streamSetS tidal
     setR = streamSetR tidal
@@ -80,6 +90,7 @@ let setI = streamSetI tidal
 :set prompt "tidal> "
 :set prompt-cont ""
 
+default (Pattern String, Integer, Double)
 ```
 
 ## Controlling Latency

--- a/docs/configuration/boottidal.md
+++ b/docs/configuration/boottidal.md
@@ -7,7 +7,7 @@ Everytime you start Tidal, the software is reading from a configuration file usu
 
 Some users went really far into customizing their setup: [Jarmlib](https://github.com/jarmitage/jarmlib). You can take a look at their work to see how to extend your configuration file.
 
-As an example, here is the *vanilla* `BootTidal.hs` file used by the [Pulsar Package for Tidal](https://raw.githubusercontent.com/tidalcycles/pulsar-tidalcycles/master/lib/BootTidal.hs):
+As an example, here is the *vanilla* `BootTidal.hs` file used by the [upstream Tidal Package](https://github.com/tidalcycles/Tidal/blob/1.9-dev/BootTidal.hs):
 ```haskell
 :set -XOverloadedStrings
 :set prompt ""


### PR DESCRIPTION
This PR updates `BootTidal.hs` to include the various changes made upstream since it was added to the docs in #4 (back in May 2021).

I wonder if there's a good way to make [BootTidal.hs](https://raw.githubusercontent.com/tidalcycles/pulsar-tidalcycles/master/lib/BootTidal.hs) the source of truth for the version embedded in the docs. It's already linked on the page, but the embedded snippet gets out-of-sync with the file it's referencing.

Client-side (runtime) options:
- Use JS and `fetch()`.
- Use an `<iframe>`.

Both options ensure that BootTidal will appear up-to-date, but complicate syntax highlighting and make the docs less self-contained.

Server-side (build time) options: 
- Do something custom to fetch `BootTidal.hs` at build time and inject it into `boottidal.md`.
- Use [snipsync](https://github.com/temporalio/snipsync), which has [docusaurus integration](https://github.com/temporalio/docusaurus-plugin-snipsync).

Or perhaps these are all overkill and the occasional PR works well enough.
(For context, I noticed that this page was stale because I wanted `unmuteAll`, went to write `unmuteAll`, and then belatedly realized that `unmuteAll` [already existed](https://github.com/tidalcycles/Tidal/commit/faef810f4b4f7ffd0572d8179b9a8160c7a48010), but I didn't have it because my `BootTidal.hs` was based on the version in the docs.)
Alternatively, the embedded version could just be removed, such that readers click the link and get the current version.

Bonus question: should this page link to the `BootTidal.hs` in the [Pulsar package](https://raw.githubusercontent.com/tidalcycles/pulsar-tidalcycles/master/lib/BootTidal.hs) or [the latest release of Tidal](https://raw.githubusercontent.com/tidalcycles/Tidal/v1.9.4/BootTidal.hs)? These are currently identical, but it seems like the former (which is what the docs link to now) is a copy of the latter, in which case maybe it's better to link to the original source.