### PR TITLE
blog edits

### DIFF
--- a/blog/2019-05-30-welcome.md
+++ b/blog/2019-05-30-welcome.md
@@ -1,8 +1,0 @@
----
-title: New Documentation
-author: Raphaël Forment
-author_title: Tidal Cyclist
-author_image_url: https://club.tidalcycles.org/user_avatar/club.tidalcycles.org/raph/240/45_2.png
----
-
-I've started working on a major overhaul / reorganization of the old [Tidal Userbase](https://tidalcycles.org/Userbase) website. I think that this new documentation is now pretty much on par with the old one. I hope that you will like it.

--- a/blog/about.md
+++ b/blog/about.md
@@ -1,24 +1,29 @@
 ---
 title: Tidal Blog Info
-date: 2023-01-01
+date: 2023-10-01
 ---
 
 ## Purpose
 The Tidal Cycles blog is intended to be **by -- for -- about** the Tidal community.
-Anyone engaged with Tidal Cycles is encouraged to submit a blog post. Topics can be about Tidal practices, music made with Tidal, live coding, event coverage, new developments & releases, community, etc. Topics can also be broader -- anything that would be of interest to this community, and it doesn't have to be limited to just about Tidal!
+Anyone engaged with Tidal Cycles is encouraged to submit a blog post. Topics can be about Tidal practices, music made with Tidal, live coding, event coverage, new developments & releases, community, etc. Topics can also be broader -- anything that would be of interest to this community, and it doesn't have to be limited to Tidal!
 
 ## Templates
-To make participation and submitting posts easier, there are a set if templates. These produce a set of patterned blog posts. Each template includes a suggested set of content sections, but consider this just a starting point. The most important thing is to provide content that reflects your unique perspective.
+To make submitting posts easier, there are a set if templates. Each template includes a suggested set of content sections, but consider this just a starting point. The most important thing is to provide content that reflects your unique perspective.
 
 Templates are maintained in GitHub in the [tidalcycles/tidal-doc](https://github.com/tidalcycles/tidal-doc/) repo / templates branch.
 
-- [Tidal Blog Profile](https://github.com/tidalcycles/tidal-doc/blob/templates/templates/blog_tidal_profile.md) Intended to highlight your livecoding practices, music, and use of tidal. Contains a set of questions to respond to.a
-  
-- [Tidal music](https://github.com/tidalcycles/tidal-doc/blob/templates/templates/blog_tidal_music.md) Use this to describe a music project such as a new album or music release, a review of a music project, Algorave or concert, or discussion of music made with Tidal or other live coding program.a
+- [Tidal Blog Profile](https://github.com/tidalcycles/tidal-doc/blob/templates/templates/blog_tidal_profile.md) Intended to highlight your livecoding practices, music, and use of tidal. It contains a set of questions to respond to.
 
-- [Blog Topic](https://github.com/tidalcycles/tidal-doc/blob/templates/templates/blog_topic.md) Open topic. Use this for a more free-form approach. One option is to present your own approach to Tidal and live coding (see [Working with Samples the Heavy Lifting way](https://tidalcycles.org/blog/tidal_profile_heavylifting)). Other topics could be discussion of a new release and the coding behind it, or discussion of other environments like Strudel, Vortex, Sardine, etc.
+- [Tidal music](https://github.com/tidalcycles/tidal-doc/blob/templates/templates/blog_tidal_music.md) Use this to describe a music project such as a new album or music release, a review of a music project, Algorave or concert, or discussion of music made with Tidal or other live coding program. Examples:
+    - [Xuixo EP by Relyt R](https://tidalcycles.org/blog/blog_topic_relyt_r_xuixo)
+    - [QBRNTHSS - making a live coding album](https://tidalcycles.org/blog/blog_topic_qbrnthss)
 
-- [Playlist](https://github.com/tidalcycles/tidal-doc/blob/templates/templates/blog_playlist.md) Use this to create a new playlist. See the [Tidal Eclectic Playlist](https://tidalcycles.org/blog/tidal_playlist-eclectic) for an example. 
+- [Blog Topic](https://github.com/tidalcycles/tidal-doc/blob/templates/templates/blog_topic.md) Open topic. Use this for a more free-form approach. One option is to present your own approach to Tidal and live coding. Other topics could be discussion of a new release and the coding behind it, or discussion of other environments like Strudel. Examples:
+    - [Working with Samples the Heavy Lifting way](https://tidalcycles.org/blog/tidal_profile_heavylifting)
+    - [How Link became Tidal's scheduler](https://tidalcycles.org/blog/link_as_scheduler)
+    - [Visualization with Didactic Pattern Visualizer](https://tidalcycles.org/blog/blog_topic_visualizer)
+
+- [Playlist](https://github.com/tidalcycles/tidal-doc/blob/templates/templates/blog_playlist.md) Use this to create a new playlist. See the [Tidal Eclectic Playlist](https://tidalcycles.org/blog/tidal_playlist-eclectic).
 
 We encourage posts to include:
 - code sections with Tidal examples
@@ -67,13 +72,13 @@ When using admonitions - be sure to add empty lines before and after your text l
   <summary>Toggle for code block</summary>
   <div>
     <div>
-      
+
 ```
 h1 $ s "sound"
 h2
 h3
 ```
-      
+
     </div>
     <br/>
   </div>
@@ -81,13 +86,13 @@ h3
 
 <details>
   <summary>Toggle for code block - (no div)</summary>
-  
+
   ```
   h1 $ s "sound"
   h2
   h3
   ```
-  
+
 </details>
 
 :::info

--- a/blog/about.md
+++ b/blog/about.md
@@ -62,32 +62,15 @@ When using admonitions - be sure to add empty lines before and after your text l
 
 <details>
   <summary>Toggle to see more</summary>
-  <div>
     <div>This is the detail revealed. This is useful for a long code block, allowing users flexibility in how they read through your post. </div>
-    <br/>
-  </div>
 </details>
 
-<details>
-  <summary>Toggle for code block</summary>
-  <div>
-    <div>
-
-```
-h1 $ s "sound"
-h2
-h3
-```
-
-    </div>
-    <br/>
-  </div>
-</details>
+Another "details" segment, with code:
 
 <details>
   <summary>Toggle for code block - (no div)</summary>
 
-  ```
+  ```haskell
   h1 $ s "sound"
   h2
   h3


### PR DESCRIPTION
Removed the (very outdated) welcome post from 2019 about the wiki migration. Improved the About page.