### PR TITLE
Fix broken video aspect ratios

### DIFF
--- a/src/components/youtube/index.jsx
+++ b/src/components/youtube/index.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { video } from "./styles.module.css";
+import styles from "./styles.module.css";
 
 /**
  * Component for embedding YouTube videos
@@ -12,7 +12,7 @@ import { video } from "./styles.module.css";
  */
 export function YouTube({ id, aspect = 16 / 9 }) {
   return (
-    <figure className={video} style={{ paddingBottom: `${100/aspect}%` }}>
+    <figure className={styles.video} style={{ paddingBottom: `${100/aspect}%` }}>
       <iframe
         src={`https://www.youtube.com/embed/${id}`}
         frameBorder="0"


### PR DESCRIPTION
# Problem:
<img width="685" alt="Screenshot 2024-05-01 at 22 12 44" src="https://github.com/tidalcycles/tidal-doc/assets/1709263/089d16f1-bbba-441b-9102-50271ef6247b">

# Fix:
<img width="584" alt="Screenshot 2024-05-01 at 22 48 53" src="https://github.com/tidalcycles/tidal-doc/assets/1709263/0c681589-5d27-4daf-afae-6c7c56bc7cce">
