### PR TITLE
Use dev branch for link to midi-osc-bridge.pd

### DIFF
--- a/docs/configuration/MIDIOSC/MIDI.md
+++ b/docs/configuration/MIDIOSC/MIDI.md
@@ -592,4 +592,4 @@ d1 $ drum "bd sd rush"
 
 ### Alternative with Pure Data
 
-The above **SuperCollider** instructions are most convenient if you're using **SuperDirt**, but as an alternative you can use **Pure Data** to convert midi to **OSC**. You can get puredata from [here](https://puredata.info/) (the `vanilla` version is recommended). Then, download [this file](https://raw.githubusercontent.com/tidalcycles/Tidal/main/pd/midi-osc-bridge.pd). Then if you start **Tidal**, open that file in **Pure Data**, and configure your **MIDI** device in **Pure Data**, things should start working.
+The above **SuperCollider** instructions are most convenient if you're using **SuperDirt**, but as an alternative you can use **Pure Data** to convert midi to **OSC**. You can get puredata from [here](https://puredata.info/) (the `vanilla` version is recommended). Then, download [this file](https://raw.githubusercontent.com/tidalcycles/Tidal/dev/pd/midi-osc-bridge.pd). Then if you start **Tidal**, open that file in **Pure Data**, and configure your **MIDI** device in **Pure Data**, things should start working.

--- a/docs/working-with-patterns/Controller_Input.md
+++ b/docs/working-with-patterns/Controller_Input.md
@@ -191,7 +191,7 @@ OSC. You can get puredata from <https://puredata.info/> (the 'vanilla'
 version is recommended).
 
 Then download this file:
-<https://raw.githubusercontent.com/tidalcycles/Tidal/main/pd/midi-osc-bridge.pd>
+<https://raw.githubusercontent.com/tidalcycles/Tidal/dev/pd/midi-osc-bridge.pd>
 
 Then if you start tidal, open that file in puredata, and configure your
 MIDI device in puredata, things should start working.


### PR DESCRIPTION
Noticed that the link for this script is broken. Technically it would be good to always link to the latest release version, I guess, but seeing how this pd script isn't really depending much on the inner workings of Tidal I think it's fine to just use `dev`. I checked for other links into the Tidal github repo but wasn't sure how to deal with them honestly, because they used different branches and the ones I checked still work.

PS: Ah, I think I figured out how the bad link snuck in. It uses `main` for the trunk branch, whereas other links use `master`, which is the one currently in use by the Tidal repo. I don't know if there ever was a plan to change the branch name.